### PR TITLE
Add Resource Tracking Decorator

### DIFF
--- a/gnn_model/EndToEndGNN.py
+++ b/gnn_model/EndToEndGNN.py
@@ -41,7 +41,7 @@ def timing_resource_decorator(func):
         # Record system resource usage AFTER execution
         mem_after = process.memory_info().rss / (1024**3)
         disk_after = psutil.disk_usage('/').used / (1024**3)
-        cpu_after = psutil.cpu_percent(interval=None) # Snapshot after execution
+        cpu_after = psutil.cpu_percent(interval=None)  # Snapshot after execution
 
         execution_time = end_time - start_time
 

--- a/gnn_model/EndToEndGNN.py
+++ b/gnn_model/EndToEndGNN.py
@@ -28,20 +28,23 @@ def timing_resource_decorator(func):
     """
     def wrapper(*args, **kwargs):
         process = psutil.Process(os.getpid())
+
+        # Record system resource usage BEFORE execution
+        mem_before = process.memory_info().rss / (1024**3)  # GB
+        disk_before = psutil.disk_usage('/').used / (1024**3)
+        cpu_before = psutil.cpu_percent(interval=None)  # Snapshot before execution
+
         start_time = time.time()
         result = func(*args, **kwargs)
         end_time = time.time()
+
+        # Record system resource usage AFTER execution
+        mem_after = process.memory_info().rss / (1024**3)
+        disk_after = psutil.disk_usage('/').used / (1024**3)
+        cpu_after = psutil.cpu_percent(interval=None) # Snapshot after execution
+
         execution_time = end_time - start_time
 
-        # Record system resource usage before execution
-        mem_before = process.memory_info().rss / (1024**3)  # Convert bytes to GB
-        cpu_before = psutil.cpu_percent(interval=None)  # Don't wait for interval
-        disk_before = psutil.disk_usage('/').used / (1024**3)  # Disk in GB
-
-        # Record system resource usage after execution
-        mem_after = process.memory_info().rss / (1024**3)
-        cpu_after = psutil.cpu_percent(interval=None)
-        disk_after = psutil.disk_usage('/').used / (1024**3)
         # Print execution time and resource usage
         print(f"Function '{func.__name__}' took {execution_time:.6f} seconds to execute.")
         print(f"  Execution Time: {execution_time:.6f} seconds")
@@ -49,6 +52,7 @@ def timing_resource_decorator(func):
         print(f"  CPU Usage: {cpu_before:.2f}% → {cpu_after:.2f}%")
         print(f"  Disk Usage: {disk_before:.2f} GB → {disk_after:.2f} GB\n")
         return result
+
     return wrapper
 
 

--- a/gnn_model/EndToEndGNN.py
+++ b/gnn_model/EndToEndGNN.py
@@ -77,11 +77,11 @@ def organize_bins_times(z, start_date, end_date, selected_satelliteId):
     satellite_ids = z["satelliteId"][:]
 
     # Select data based on the given time range and satellite ID
-    selected_times = np.where((time >= start_date) & (time <= end_date) & (satellite_ids == 224))[0]
+    selected_times = np.where((time >= start_date) & (time <= end_date) & (satellite_ids == selected_satelliteId))[0]
 
     # Filter data for the specified week and satellite
     df = pd.DataFrame({"time": time[selected_times], "zar_time": z["time"][selected_times]})
-    df["index"] = np.where((time >= start_date) & (time <= end_date) & (satellite_ids == 224))[0]
+    df["index"] = np.where((time >= start_date) & (time <= end_date) & (satellite_ids == selected_satelliteId))[0]
     df["time_bin"] = df["time"].dt.floor("12h")
 
     # Sort by time
@@ -674,11 +674,11 @@ def main():
     ############################################################################################
     # Define parameters
     start_date = "2024-04-01"
-    end_date = "2024-04-07"
+    end_date = "2024-04-02"
     selected_satelliteId = 224
 
     # Open Zarr dataset
-    z = zarr.open("/scratch1/NCEPDEV/da/Ronald.McLaren/shared/ocelot/data_v2/atms.zarr", mode="r")
+    z = zarr.open("/scratch1/NCEPDEV/da/Ronald.McLaren/shared/ocelot/data_v2/atms_small.zarr", mode="r")
 
     # make pair of input-target data for each time step
     data_summary = organize_bins_times(z, start_date, end_date, selected_satelliteId)
@@ -738,9 +738,9 @@ def main():
 
     # Define pytorch model parameters
     input_dim = 27
-    hidden_dim = 128  # Reduced hidden dimension to avoid memory issues
+    hidden_dim = 64  # Reduced hidden dimension to avoid memory issues
     output_dim = 24
-    num_layers = 16
+    num_layers = 8
 
     # Instantiate the model
     gnn_model = GNNModel(input_dim, hidden_dim, output_dim, num_layers)
@@ -764,7 +764,7 @@ def main():
     edge_index_target = hetero_data["hidden", "to", "target"].edge_index
 
     # Train Model
-    trained_model = train_model(gnn_model, hidden_data, edge_index_target, hidden_data.y, epochs=10, lr=1e-4)
+    trained_model = train_model(gnn_model, hidden_data, edge_index_target, hidden_data.y, epochs=3, lr=1e-3)
 
 
 if __name__ == "__main__":

--- a/gnn_model/EndToEndGNN.py
+++ b/gnn_model/EndToEndGNN.py
@@ -47,7 +47,6 @@ def timing_resource_decorator(func):
 
         # Print execution time and resource usage
         print(f"Function '{func.__name__}' took {execution_time:.6f} seconds to execute.")
-        print(f"  Execution Time: {execution_time:.6f} seconds")
         print(f"  Memory Usage: {mem_before:.2f} GB → {mem_after:.2f} GB")
         print(f"  CPU Usage: {cpu_before:.2f}% → {cpu_after:.2f}%")
         print(f"  Disk Usage: {disk_before:.2f} GB → {disk_after:.2f} GB\n")


### PR DESCRIPTION
This PR addresses issue #6  and introduces the following changes:
1.  Modifies the existing timing_decorator to `timing_resource_decorator`, which now logs:
- Execution Time
- Memory Usage
- CPU Usage
- Disk Usage

2. Provides smaller Test Case

- Updated the Zarr input file to a smaller dataset (7 days instead of 3 months)

- Adjusted model training parameters to reduce resource usage:

These changes help keep the test case well within GitHub CI resource limits and make performance tracking easier for each function.