### PR TITLE
Implement weekly segmentation for Zarr outputs

### DIFF
--- a/data_prep/README.md
+++ b/data_prep/README.md
@@ -30,9 +30,16 @@ options:
   -b, --batch           Run in batch mode (using sbatch). 
                         Chunks the data into multiple tasks if needed.
   -a, --append          Append to existing data
+
   --slurm_account SLURM_ACCOUNT
                         SLURM account name for batch jobs
 ```
+
+The generated Zarr files now contain at most one week of data. Files are named
+`<type>_<suffix>_<YYYYMMDD>_<YYYYMMDD>.zarr` (the suffix portion is omitted if
+not provided) where the dates represent the Monday-Sunday range for that week.
+Subsequent runs automatically append to these files when processing additional
+days within the same week.
 
 ## Configuration /  Mapping files
 

--- a/data_prep/src/create_data.py
+++ b/data_prep/src/create_data.py
@@ -11,7 +11,11 @@ import data_reader  # noqa: E402
 import settings  # noqa: E402
 
 
-def create_data_for_day(comm, date: datetime, type: str, suffix: str = None, append: bool = True):
+def create_data_for_day(comm,
+                        date: datetime,
+                        type: str,
+                        output_path: str,
+                        append: bool = True) -> None:
     start_datetime = date
     end_datetime = date + timedelta(hours=23, minutes=59, seconds=59)
 
@@ -42,11 +46,6 @@ def create_data_for_day(comm, date: datetime, type: str, suffix: str = None, app
         container = container.apply_mask(mask)
 
     if comm.rank() == 0:
-        if suffix:
-            output_path = os.path.join(settings.OUTPUT_PATH, f'{type}_{suffix}.zarr')
-        else:
-            output_path = os.path.join(settings.OUTPUT_PATH, f'{type}.zarr')
-
         Encoder(description).encode(container, output_path, append=append)
         print(f"Output written to {output_path}")
         sys.stdout.flush()
@@ -56,15 +55,51 @@ def create_data(start_date: datetime,
                 end_date: datetime,
                 type: str,
                 suffix: str = None,
-                append: bool = True):
-    date = start_date
-    day = timedelta(days=1)
+                append: bool = True) -> None:
+    """Create zarr files from BUFR data in week long chunks."""
 
     bufr.mpi.App(sys.argv)
     comm = bufr.mpi.Comm("world")
 
+    # Determine all week boundaries (Monday - Sunday) that intersect the range
+    week_start = start_date - timedelta(days=start_date.weekday())
+    week_ranges = []
+    while week_start <= end_date:
+        week_end = week_start + timedelta(days=6)
+        week_ranges.append((week_start, week_end))
+        week_start = week_end + timedelta(days=1)
+
+    # Generate output paths for each week
+    output_paths = {}
+    for wstart, wend in week_ranges:
+        if suffix:
+            file_name = f"{type}_{suffix}_{wstart:%Y%m%d}_{wend:%Y%m%d}.zarr"
+        else:
+            file_name = f"{type}_{wstart:%Y%m%d}_{wend:%Y%m%d}.zarr"
+        output_paths[(wstart, wend)] = os.path.join(settings.OUTPUT_PATH, file_name)
+
+    if comm.rank() == 0:
+        # Ensure all output directories exist before processing
+        for path in output_paths.values():
+            if not append and os.path.exists(path):
+                import shutil
+                shutil.rmtree(path)
+            os.makedirs(path, exist_ok=True)
+    comm.barrier()
+
+    # Process each day and append to the appropriate weekly file
+    day = timedelta(days=1)
+    date = start_date
     while date <= end_date:
-        create_data_for_day(comm, date, type, suffix, append)
+        week_start = date - timedelta(days=date.weekday())
+        week_end = week_start + timedelta(days=6)
+        out_path = output_paths[(week_start, week_end)]
+
+        # Determine if the file already contains data
+        exists = os.path.exists(os.path.join(out_path, '.zgroup'))
+        append_flag = append and exists
+
+        create_data_for_day(comm, date, type, out_path, append=append_flag)
         date += day
 
 


### PR DESCRIPTION
## Summary
- chunk data into Monday--Sunday files
- append to existing files when weeks span multiple jobs
- document new weekly output behaviour

## Testing
- `python -m py_compile data_prep/src/create_data.py`