### PR TITLE
Fix pycodestyle issues

### DIFF
--- a/data_prep/mapping/bufr_atms.py
+++ b/data_prep/mapping/bufr_atms.py
@@ -16,7 +16,6 @@ class AtmsObsBuilder(ObsBuilder):
         container = super().make_obs(comm, input_path)
 
         quality_flags = container.get('qualityFlags')
-        brightness_temp = container.get('brightnessTemperature')
 
         # Mask out values with non-zero quality flags
         container.apply_mask(quality_flags == 0)

--- a/data_prep/mapping/bufr_radiosonde.py
+++ b/data_prep/mapping/bufr_radiosonde.py
@@ -28,11 +28,13 @@ class RadiosondeObsBuilder(ObsBuilder):
         container.apply_mask(~container.get('obsTimeMinusCycleTime').mask)
 
         # Mask out values with invalid quality flags
-        quality_mask = container.get('airTemperatureQuality') <= 3 & \
-                       container.get('specificHumidityQuality') <= 3 & \
-                       container.get('windQuality') <= 3 & \
-                       container.get('airPressureQuality') <= 3 & \
-                       container.get('heightQuality') <= 3
+        quality_mask = (
+            (container.get('airTemperatureQuality') <= 3)
+            & (container.get('specificHumidityQuality') <= 3)
+            & (container.get('windQuality') <= 3)
+            & (container.get('airPressureQuality') <= 3)
+            & (container.get('heightQuality') <= 3)
+        )
 
         container.apply_mask(quality_mask)
 

--- a/data_prep/mapping/bufr_surface_obs.py
+++ b/data_prep/mapping/bufr_surface_obs.py
@@ -36,12 +36,14 @@ class PressureObsBuilder(ObsBuilder):
         container.apply_mask(~container.get('obsTimeMinusCycleTime').mask)
 
         # Apply Quality Masks
-        quality_mask = container.get('airTemperatureQuality') <= 3 & \
-                       container.get('specificHumidityQuality') <= 3 & \
-                       container.get('windQuality') <= 3 & \
-                       container.get('airPressureQuality') <= 3 & \
-                       container.get('heightQuality') <= 3 & \
-                       container.get('seaTemperatureQuality') <= 3
+        quality_mask = (
+            (container.get('airTemperatureQuality') <= 3)
+            & (container.get('specificHumidityQuality') <= 3)
+            & (container.get('windQuality') <= 3)
+            & (container.get('airPressureQuality') <= 3)
+            & (container.get('heightQuality') <= 3)
+            & (container.get('seaTemperatureQuality') <= 3)
+        )
 
         container.apply_mask(quality_mask)
 


### PR DESCRIPTION
## Summary
- clean up unused variable in ATMS mapping
- fix indentation in radiosonde and surface obs mappings

## Testing
- `pycodestyle data_prep/mapping/bufr_atms.py data_prep/mapping/bufr_radiosonde.py data_prep/mapping/bufr_surface_obs.py` *(fails: command not found)*