### PR TITLE
Feature/loss gc

### DIFF
--- a/gnn_model/gnn_datamodule.py
+++ b/gnn_model/gnn_datamodule.py
@@ -131,9 +131,6 @@ class BinDataset(Dataset):
             target_lat_deg=tensor_conversion(data_dict["target_lat_deg"], dtype=torch.float32),
             target_lon_deg=tensor_conversion(data_dict["target_lon_deg"], dtype=torch.float32),
             target_metadata=data_dict["target_metadata"],
-            # target_lat_deg=torch.tensor(data_dict["target_lat_deg"], dtype=torch.float32),
-            # target_lon_deg=torch.tensor(data_dict["target_lon_deg"], dtype=torch.float32),
-            # target_metadata=torch.tensor(data_dict["target_metadata"], dtype=torch.float32),
         )
 
 
@@ -361,11 +358,6 @@ class GNNDataModule(pl.LightningDataModule):
             "input_instrument_ids": tensor_conversion(bin_data["input_instrument_ids"], dtype=torch.long),
             "target_instrument_ids": tensor_conversion(bin_data["target_instrument_ids"], dtype=torch.long),
             "target_metadata": tensor_conversion(bin_data["target_metadata"], dtype=torch.float32),
-            # "target_scaler_min": torch.tensor(bin_data["target_scaler_min"], dtype=torch.float32),
-            # "target_scaler_max": torch.tensor(bin_data["target_scaler_max"], dtype=torch.float32),
-            # "input_instrument_ids": torch.tensor(bin_data["input_instrument_ids"], dtype=torch.long),
-            # "target_instrument_ids": torch.tensor(bin_data["target_instrument_ids"], dtype=torch.long),
-            # "target_metadata": torch.tensor(bin_data["target_metadata"], dtype=torch.float32),
         }
 
     def _create_data_object(self, data_dict):
@@ -374,12 +366,6 @@ class GNNDataModule(pl.LightningDataModule):
 
         Adds additional fields needed for later unnormalization (e.g., for evaluation).
         """
-        # MK: this seems a redundency?
-        # if "instrument_ids" in data_dict:
-        #     instrument_ids = torch.tensor(data_dict["instrument_ids"], dtype=torch.long)
-        # else:
-        #     instrument_ids = None
-
         data_args = dict(
             x=data_dict["x"],
             edge_index_encoder=data_dict["edge_index_encoder"],
@@ -392,13 +378,10 @@ class GNNDataModule(pl.LightningDataModule):
             target_scaler_max=data_dict["target_scaler_max"],
             target_lat_deg=tensor_conversion(data_dict["target_lat_deg"], dtype=torch.float32),
             target_lon_deg=tensor_conversion(data_dict["target_lon_deg"], dtype=torch.float32),
-            # target_lat_deg=torch.tensor(data_dict["target_lat_deg"], dtype=torch.float32),
-            # target_lon_deg=torch.tensor(data_dict["target_lon_deg"], dtype=torch.float32),
         )
         # Optional: add instrument_ids only if present
         if "instrument_ids" in data_dict:
             data_args["instrument_ids"] = tensor_conversion(data_dict["instrument_ids"], dtype=torch.long)
-            # data_args["instrument_ids"] = torch.tensor(data_dict["instrument_ids"], dtype=torch.long)
 
         return Data(**data_args)
 

--- a/gnn_model/gnn_datamodule.py
+++ b/gnn_model/gnn_datamodule.py
@@ -90,7 +90,7 @@ class BinDataset(Dataset):
             target_scaler_max=data_dict["target_scaler_max"],
             target_lat_deg=torch.tensor(data_dict["target_lat_deg"], dtype=torch.float32),
             target_lon_deg=torch.tensor(data_dict["target_lon_deg"], dtype=torch.float32),
-            instrument_ids=data_dict["target_instrument_ids"]
+            instrument_ids=data_dict["target_instrument_ids"],
             bin_name=data_dict["bin_name"],
             target_metadata=torch.tensor(data_dict["target_metadata"], dtype=torch.float32),
         )

--- a/gnn_model/gnn_datamodule.py
+++ b/gnn_model/gnn_datamodule.py
@@ -67,6 +67,10 @@ class BinDataset(Dataset):
             bin = self.data_summary[bin_name]
             bin, _ = flatten_data(bin)
             data_dict = self.create_graph_fn(bin)
+            data_dict['bin_name'] = bin_name  # Add bin_name to data_dict
+            print(
+                f"[{bin_name}] Input features shape: {bin['input_features_final'].shape}, Target features shape: {bin['target_features_final'].shape}"
+            )
         except Exception as e:
             print(f"[Rank {rank}] Error in bin {bin_name}: {e}")
             raise
@@ -87,6 +91,8 @@ class BinDataset(Dataset):
             target_lat_deg=torch.tensor(data_dict["target_lat_deg"], dtype=torch.float32),
             target_lon_deg=torch.tensor(data_dict["target_lon_deg"], dtype=torch.float32),
             instrument_ids=data_dict["target_instrument_ids"]
+            bin_name=data_dict["bin_name"],
+            target_metadata=torch.tensor(data_dict["target_metadata"], dtype=torch.float32),
         )
 
 
@@ -313,6 +319,7 @@ class GNNDataModule(pl.LightningDataModule):
             "target_lon_deg": bin_data["target_lon_deg"],
             "input_instrument_ids": torch.tensor(bin_data["input_instrument_ids"], dtype=torch.long),
             "target_instrument_ids": torch.tensor(bin_data["target_instrument_ids"], dtype=torch.long),
+            "target_metadata": torch.tensor(bin_data["target_metadata"], dtype=torch.float32),
         }
 
     def _create_data_object(self, data_dict):

--- a/gnn_model/gnn_datamodule.py
+++ b/gnn_model/gnn_datamodule.py
@@ -19,6 +19,44 @@ from obs_to_mesh import ObsMeshCutoffConnector
 from process_timeseries import extract_features, organize_bins_times, flatten_data
 
 
+def tensor_conversion(data, dtype=torch.float32, device=None):
+    """
+    Convert data to tensor efficiently without unnecessary copies.
+
+    Current inefficient code in gnn_datamodule.py:
+        e.g., "target_scaler_min": torch.tensor(bin_data["target_scaler_min"], dtype=torch.float32)
+        This doubles up memory usage by creating a new tensor copy in memory
+
+    Args:
+        data: Input data (tensor, numpy array, list, etc.)
+        dtype: Target data type
+        device: Target device (optional)
+
+    Returns:
+        torch.Tensor: Efficiently converted tensor
+    """
+    if isinstance(data, torch.Tensor):
+        # Already a tensor - minimize operations
+        result = data
+
+        # Change dtype if needed
+        if result.dtype != dtype:
+            result = result.to(dtype)
+
+        # Change device if needed
+        if device is not None and result.device != device:
+            result = result.to(device)
+
+        # Always detach to avoid gradient issues
+        return result.detach()
+    else:
+        # Not a tensor - create new one efficiently
+        if device is not None:
+            return torch.tensor(data, dtype=dtype, device=device)
+        else:
+            return torch.tensor(data, dtype=dtype)
+
+
 @rank_zero_only
 def log_system_info():
     """
@@ -88,11 +126,14 @@ class BinDataset(Dataset):
             y=data_dict["y"],
             target_scaler_min=data_dict["target_scaler_min"],
             target_scaler_max=data_dict["target_scaler_max"],
-            target_lat_deg=torch.tensor(data_dict["target_lat_deg"], dtype=torch.float32),
-            target_lon_deg=torch.tensor(data_dict["target_lon_deg"], dtype=torch.float32),
-            instrument_ids=data_dict["target_instrument_ids"],
+            instrument_ids=data_dict["target_instrument_ids"],  # MK: should this be named as target_instrument_ids?
             bin_name=data_dict["bin_name"],
-            target_metadata=torch.tensor(data_dict["target_metadata"], dtype=torch.float32),
+            target_lat_deg=tensor_conversion(data_dict["target_lat_deg"], dtype=torch.float32),
+            target_lon_deg=tensor_conversion(data_dict["target_lon_deg"], dtype=torch.float32),
+            target_metadata=data_dict["target_metadata"],
+            # target_lat_deg=torch.tensor(data_dict["target_lat_deg"], dtype=torch.float32),
+            # target_lon_deg=torch.tensor(data_dict["target_lon_deg"], dtype=torch.float32),
+            # target_metadata=torch.tensor(data_dict["target_metadata"], dtype=torch.float32),
         )
 
 
@@ -313,13 +354,18 @@ class GNNDataModule(pl.LightningDataModule):
             "edge_index_decoder": edge_index_decoder_global.to(torch.long),
             "edge_attr_decoder": edge_attr_knn,
             "y": target_features,  # Flattened target features
-            "target_scaler_min": torch.tensor(bin_data["target_scaler_min"], dtype=torch.float32),
-            "target_scaler_max": torch.tensor(bin_data["target_scaler_max"], dtype=torch.float32),
             "target_lat_deg": bin_data["target_lat_deg"],
             "target_lon_deg": bin_data["target_lon_deg"],
-            "input_instrument_ids": torch.tensor(bin_data["input_instrument_ids"], dtype=torch.long),
-            "target_instrument_ids": torch.tensor(bin_data["target_instrument_ids"], dtype=torch.long),
-            "target_metadata": torch.tensor(bin_data["target_metadata"], dtype=torch.float32),
+            "target_scaler_min": tensor_conversion(bin_data["target_scaler_min"], dtype=torch.float32),
+            "target_scaler_max": tensor_conversion(bin_data["target_scaler_max"], dtype=torch.float32),
+            "input_instrument_ids": tensor_conversion(bin_data["input_instrument_ids"], dtype=torch.long),
+            "target_instrument_ids": tensor_conversion(bin_data["target_instrument_ids"], dtype=torch.long),
+            "target_metadata": tensor_conversion(bin_data["target_metadata"], dtype=torch.float32),
+            # "target_scaler_min": torch.tensor(bin_data["target_scaler_min"], dtype=torch.float32),
+            # "target_scaler_max": torch.tensor(bin_data["target_scaler_max"], dtype=torch.float32),
+            # "input_instrument_ids": torch.tensor(bin_data["input_instrument_ids"], dtype=torch.long),
+            # "target_instrument_ids": torch.tensor(bin_data["target_instrument_ids"], dtype=torch.long),
+            # "target_metadata": torch.tensor(bin_data["target_metadata"], dtype=torch.float32),
         }
 
     def _create_data_object(self, data_dict):
@@ -328,10 +374,11 @@ class GNNDataModule(pl.LightningDataModule):
 
         Adds additional fields needed for later unnormalization (e.g., for evaluation).
         """
-        if "instrument_ids" in data_dict:
-            instrument_ids = torch.tensor(data_dict["instrument_ids"], dtype=torch.long)
-        else:
-            instrument_ids = None
+        # MK: this seems a redundency?
+        # if "instrument_ids" in data_dict:
+        #     instrument_ids = torch.tensor(data_dict["instrument_ids"], dtype=torch.long)
+        # else:
+        #     instrument_ids = None
 
         data_args = dict(
             x=data_dict["x"],
@@ -343,12 +390,15 @@ class GNNDataModule(pl.LightningDataModule):
             y=data_dict["y"],
             target_scaler_min=data_dict["target_scaler_min"],
             target_scaler_max=data_dict["target_scaler_max"],
-            target_lat_deg=torch.tensor(data_dict["target_lat_deg"], dtype=torch.float32),
-            target_lon_deg=torch.tensor(data_dict["target_lon_deg"], dtype=torch.float32),
+            target_lat_deg=tensor_conversion(data_dict["target_lat_deg"], dtype=torch.float32),
+            target_lon_deg=tensor_conversion(data_dict["target_lon_deg"], dtype=torch.float32),
+            # target_lat_deg=torch.tensor(data_dict["target_lat_deg"], dtype=torch.float32),
+            # target_lon_deg=torch.tensor(data_dict["target_lon_deg"], dtype=torch.float32),
         )
         # Optional: add instrument_ids only if present
         if "instrument_ids" in data_dict:
-            data_args["instrument_ids"] = torch.tensor(data_dict["instrument_ids"], dtype=torch.long)
+            data_args["instrument_ids"] = tensor_conversion(data_dict["instrument_ids"], dtype=torch.long)
+            # data_args["instrument_ids"] = torch.tensor(data_dict["instrument_ids"], dtype=torch.long)
 
         return Data(**data_args)
 

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -12,8 +12,9 @@ import torch.utils.checkpoint
 import matplotlib.pyplot as plt
 import pandas as pd
 
-#MK
+# MK
 from loss import level_weighted_mse
+
 
 class GNNLightning(pl.LightningModule):
     """

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -12,6 +12,8 @@ import torch.utils.checkpoint
 import matplotlib.pyplot as plt
 import pandas as pd
 
+#MK
+from loss import level_weighted_mse
 
 class GNNLightning(pl.LightningModule):
     """
@@ -427,6 +429,12 @@ class GNNLightning(pl.LightningModule):
         else:
             # loss = self.loss_fn(y_pred, y_true)
             loss = self.huber(y_pred, y_true).mean()  # fallback
+
+        # MK: level weighting (commented out for now)
+        # pressure_levels=None
+        # loss = level_weighted_mse(y_pred, y_true, pressure_levels)
+
+        self.log("train_loss", loss)
 
         if self.trainer.is_global_zero:
             self.debug(f"[DEBUG] MSE loss at batch {batch_idx}: {loss.item():.6f}")

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -932,7 +932,7 @@ class GNNLightning(pl.LightningModule):
             })
             df_bt.to_csv(f"bt_predictions_epoch{self.current_epoch}.csv", index=False)
 
-            # Save Pressure predictions 
+            # Save Pressure predictions
             df_pressure = pd.DataFrame({
                 "lat_deg": batch.target_lat_deg[pressure_mask_csv].cpu().numpy(),
                 "lon_deg": batch.target_lon_deg[pressure_mask_csv].cpu().numpy(),

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -922,7 +922,7 @@ class GNNLightning(pl.LightningModule):
             bt_true_csv = y_true_unnorm_csv[:, :22]
             pressure_mask_csv = (bt_true_csv[:, 1:] == 0).all(dim=1)
             bt_mask_csv = ~pressure_mask_csv
-            
+
             # Save BT predictions
             df_bt = pd.DataFrame({
                 "lat_deg": batch.target_lat_deg[bt_mask_csv].cpu().numpy(),
@@ -931,8 +931,8 @@ class GNNLightning(pl.LightningModule):
                 **{f"pred_bt_{i+1}": y_pred_unnorm_csv[bt_mask_csv, i].cpu().numpy() for i in range(22)},
             })
             df_bt.to_csv(f"bt_predictions_epoch{self.current_epoch}.csv", index=False)
-            
-            # Save Pressure predictions  
+
+            # Save Pressure predictions 
             df_pressure = pd.DataFrame({
                 "lat_deg": batch.target_lat_deg[pressure_mask_csv].cpu().numpy(),
                 "lon_deg": batch.target_lon_deg[pressure_mask_csv].cpu().numpy(),

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -157,7 +157,7 @@ class GNNLightning(pl.LightningModule):
             self.debug(f"[Forward] CUDA Mem: {torch.cuda.memory_allocated() / 1e6:.1f} MB")
         edge_index_encoder = data.edge_index_encoder
         edge_index_processor = data.edge_index_processor
-        #edge_index_decoder = data.edge_index_decoder
+        # edge_index_decoder = data.edge_index_decoder
         y = data.y
 
         # === Encoding: obs → mesh ===
@@ -462,7 +462,7 @@ class GNNLightning(pl.LightningModule):
             # GraphCast schedule based on gradient descent updates
             # testing functionality: train 1 rollout for 5 epochs [0-4], add 1 for every epoch
             threshold = 5  # 300000 # MK: using 5 for testing
-            interval  = 1  # 1000
+            interval = 1  # 1000
             if current_step < threshold:
                 return 1
             else:
@@ -515,12 +515,12 @@ class GNNLightning(pl.LightningModule):
             target_latlon_rad=target_latlon_rad.cpu().numpy(),  # Convert to numpy
             mesh_latlon_rad=mesh_latlon_rad  # Already numpy from data module
         )
- 
+
         # Calculate mesh offset
         num_mesh_nodes = len(mesh_latlon_rad)  # 642
         num_obs_nodes = mesh_state.shape[0] - num_mesh_nodes  # 28294 - 642 = 27652
         mesh_offset = num_obs_nodes
-        
+
         # Apply mesh offset to point to actual mesh nodes in mesh_state/x_hidden
         edge_index_global = edge_index.clone()
         edge_index_global[0] += mesh_offset  # Shift mesh indices
@@ -761,7 +761,7 @@ class GNNLightning(pl.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         # MK: small change for a quick test
-        #y_pred = self(batch)
+        # y_pred = self(batch)
         y_pred_list = self(batch, n_steps=1)
         y_pred = y_pred_list[0]
         y_true = batch.y

--- a/gnn_model/loss.py
+++ b/gnn_model/loss.py
@@ -1,8 +1,10 @@
 import torch
 
+
 def normalized_level_weights(pressure_levels):
     """Weights proportional to pressure at each level."""
     return pressure_levels / pressure_levels.mean()
+
 
 def level_weighted_mse(predictions, targets, pressure_levels=None):
     """

--- a/gnn_model/loss.py
+++ b/gnn_model/loss.py
@@ -1,0 +1,56 @@
+import torch
+
+def normalized_level_weights(pressure_levels):
+    """Weights proportional to pressure at each level."""
+    return pressure_levels / pressure_levels.mean()
+
+def level_weighted_mse(predictions, targets, pressure_levels=None):
+    """
+    Compute level-weighted MSE loss.
+    
+    Args:
+        predictions (torch.Tensor): Predicted values
+        targets (torch.Tensor): Target values
+        pressure_levels (torch.Tensor, optional): Pressure values for each channel.
+            If None, will use default values from 1000mb to 200mb for 22 channels.
+            
+    Returns:
+        torch.Tensor: Scalar loss value
+    """
+    # Default pressure levels if none provided
+    # We don't have data with levels now. Using 22channels as levels to trick it
+    # modify accordingly when dealing with data with levels
+    if pressure_levels is None:
+        level_num = predictions.shape[-1] #22
+        # For 22 channels, create evenly spaced values from 1000 to 200
+        pressure_levels = torch.linspace(1000, 200, level_num).to(predictions.device)
+
+    print("MK LOSS DEBUDDING:")
+    print(f"pressure levels: {pressure_levels}")
+    print(f"prediction shape: {predictions.shape}")
+    print(f"target shape: {targets.shape}")
+
+    # Get normalized weights
+    weights = normalized_level_weights(pressure_levels)
+    print(f"weights shape: {weights.shape} \n weights:")
+    print(weights)
+
+    # Reshape weights for broadcasting
+    weight_shape = [1] * (predictions.dim() - 1) + [weights.size(0)]
+    weights = weights.view(*weight_shape)
+    print(f"reshaped weights shape: {weights.shape}")
+
+    # Compute squared difference and apply weights
+    squared_diff = (predictions - targets)**2
+    weighted_squared_diff = squared_diff * weights
+
+    print(f"squared error shape: {squared_diff.shape}")
+    print(squared_diff[:5,:])
+    print(f"weighted squared error shape: {weighted_squared_diff.shape}")
+    print(weighted_squared_diff[:5,:])
+
+    # Calculate mean loss
+    loss = weighted_squared_diff.mean()
+    print(f"loss shape: {loss.shape} \n loss: {loss}")
+    
+    return loss

--- a/gnn_model/loss.py
+++ b/gnn_model/loss.py
@@ -7,13 +7,11 @@ def normalized_level_weights(pressure_levels):
 def level_weighted_mse(predictions, targets, pressure_levels=None):
     """
     Compute level-weighted MSE loss.
-    
     Args:
         predictions (torch.Tensor): Predicted values
         targets (torch.Tensor): Target values
         pressure_levels (torch.Tensor, optional): Pressure values for each channel.
             If None, will use default values from 1000mb to 200mb for 22 channels.
-            
     Returns:
         torch.Tensor: Scalar loss value
     """
@@ -21,7 +19,7 @@ def level_weighted_mse(predictions, targets, pressure_levels=None):
     # We don't have data with levels now. Using 22channels as levels to trick it
     # modify accordingly when dealing with data with levels
     if pressure_levels is None:
-        level_num = predictions.shape[-1] #22
+        level_num = predictions.shape[-1]  # 22
         # For 22 channels, create evenly spaced values from 1000 to 200
         pressure_levels = torch.linspace(1000, 200, level_num).to(predictions.device)
 
@@ -45,12 +43,12 @@ def level_weighted_mse(predictions, targets, pressure_levels=None):
     weighted_squared_diff = squared_diff * weights
 
     print(f"squared error shape: {squared_diff.shape}")
-    print(squared_diff[:5,:])
+    print(squared_diff[:5, :])
     print(f"weighted squared error shape: {weighted_squared_diff.shape}")
-    print(weighted_squared_diff[:5,:])
+    print(weighted_squared_diff[:5, :])
 
     # Calculate mean loss
     loss = weighted_squared_diff.mean()
     print(f"loss shape: {loss.shape} \n loss: {loss}")
-    
+
     return loss

--- a/gnn_model/run_gnn.sh
+++ b/gnn_model/run_gnn.sh
@@ -12,6 +12,7 @@
 #SBATCH -t 04:00:00
 #SBATCH --output=gnn_train_%j.out
 #SBATCH --error=gnn_train_%j.err
+#SBATCH --mail-type=BEGIN,END,FAIL
 
 # Load Conda environment
 # source /home/Azadeh.Gholoubi/miniconda3/etc/profile.d/conda.sh

--- a/gnn_model/train_gnn.py
+++ b/gnn_model/train_gnn.py
@@ -64,8 +64,7 @@ def main():
             # "surface_land":
         }
     }
-
-    mesh_resolution = 6  # MK: Out of Mem but I need to test #6
+    mesh_resolution = 6
 
     # === MODEL CONFIGURATION ===
     input_dim = 32
@@ -77,8 +76,7 @@ def main():
     # === TRAINING CONFIGURATION ===
     max_epochs = 10
     batch_size = 1
-    # MK: add for rollout
-    max_rollout_steps = 3  # Maximum rollout length
+    max_rollout_steps = 3  # Maximum rollout length; set 1 to have no rollout
     rollout_schedule = 'graphcast'  # 'graphcast', 'step', 'linear', or 'fixed'
 
     # # === INSTANTIATE MODEL & DATA MODULE ===

--- a/gnn_model/train_gnn.py
+++ b/gnn_model/train_gnn.py
@@ -77,7 +77,7 @@ def main():
     max_epochs = 10
     batch_size = 1
     max_rollout_steps = 3  # Maximum rollout length; set 1 to have no rollout
-    rollout_schedule = 'graphcast'  # 'graphcast', 'step', 'linear', or 'fixed'
+    rollout_schedule = 'fixed'  # 'graphcast', 'step', 'linear', or 'fixed'
 
     # # === INSTANTIATE MODEL & DATA MODULE ===
     model = GNNLightning(

--- a/gnn_model/train_gnn.py
+++ b/gnn_model/train_gnn.py
@@ -54,15 +54,15 @@ def main():
             # "goes":,
             # "ascat":
         },
-        "conventional": {
-            # "radiosonde": ,
-            "surface_pressure": {
-                "features": ["stationPressure", ],
-                "metadata": ["height", ]
-            },
-            # "surface_marine": ,
-            # "surface_land":
-        }
+        # "conventional": {
+        #     # "radiosonde": ,
+        #     "surface_pressure": {
+        #         "features": ["stationPressure", ],
+        #         "metadata": ["height", ]
+        #     },
+        #     # "surface_marine": ,
+        #     # "surface_land":
+        # }
     }
     mesh_resolution = 6
 
@@ -76,7 +76,7 @@ def main():
     # === TRAINING CONFIGURATION ===
     max_epochs = 10
     batch_size = 1
-    max_rollout_steps = 3  # Maximum rollout length; set 1 to have no rollout
+    max_rollout_steps = 2  # Maximum rollout length; set 1 to have no rollout
     rollout_schedule = 'fixed'  # 'graphcast', 'step', 'linear', or 'fixed'
 
     # # === INSTANTIATE MODEL & DATA MODULE ===

--- a/gnn_model/train_gnn.py
+++ b/gnn_model/train_gnn.py
@@ -65,7 +65,7 @@ def main():
         }
     }
 
-    mesh_resolution = 6
+    mesh_resolution = 6  # MK: Out of Mem but I need to test #6
 
     # === MODEL CONFIGURATION ===
     input_dim = 32
@@ -77,6 +77,9 @@ def main():
     # === TRAINING CONFIGURATION ===
     max_epochs = 10
     batch_size = 1
+    # MK: add for rollout
+    max_rollout_steps = 3  # Maximum rollout length
+    rollout_schedule = 'graphcast'  # 'graphcast', 'step', 'linear', or 'fixed'
 
     # # === INSTANTIATE MODEL & DATA MODULE ===
     model = GNNLightning(
@@ -88,6 +91,8 @@ def main():
         instrument_weights=instrument_weights,
         channel_weights=channel_weights,
         verbose=args.verbose,
+        max_rollout_steps=max_rollout_steps,
+        rollout_schedule=rollout_schedule,
     )
     # model = GNNLightning.load_from_checkpoint(
     #     checkpoint_path,


### PR DESCRIPTION
This update addresses issue 23 - Updating Loss and adding Multi-Step Rollout Forecasting (https://github.com/NOAA-EMC/ocelot/issues/23), which implements rollout functionality. Additionally, this code handles temporal boundaries in the data by adjusting the rollout number at the edges.

Here's how it works with 5 training bins and 2 validation bins:

```
bin1: [1,2,3] produces 3 steps with loss calculated on all 3 steps ✓
bin2: [2,3,4] produces 3 steps with loss calculated on all 3 steps ✓
bin3: [3,4,5] produces 3 steps with loss calculated on all 3 steps ✓
bin4: [4,5] produces 2 steps with loss calculated on 2 steps ✓ (at temporal boundary)
bin5: [5] produces 1 step with loss calculated on 1 step ✓ (at temporal boundary)
```

In production mode, the model generates the full requested rollout using preset projection locations. The validation code reflects this production behavior by generating the full rollout using the last time bin's location. However, only predictions with available ground truth are used for validation (loss and other evaluation metrics calculation).

```
bin6: 3-step rollout [6, 7, 7] with 2 ground truth steps [6, 7] results in loss calculated on 2 steps, with NaN placeholders logged for step 3
bin7: 3-step rollout [7, 7, 7] with 1 ground truth step [7] results in loss calculated on 1 step, with NaN placeholders logged for steps 2 and 3
```

Note that logging NaN placeholders is essential to prevent GPU hanging when `sync_dist=True` is enabled for logging.

Planned Enhancements:
1. Fixed global grid for all prediction modes (validation, testing, production)
2. An option for feeding forecast outputs back to the next prediction window (similar to GraphCast, an optional function in GraphDOP)