### PR TITLE
feat: add AMSUA, raw surface obs, and snow cover to the GNN pipeline

### DIFF
--- a/gnn_model/configs/observation_config.yaml
+++ b/gnn_model/configs/observation_config.yaml
@@ -1,7 +1,7 @@
 pipeline:
   subsample:
-    satellite: 20         # keep every N-th sample (stride); stride or keep ~1/N of samples uniformly (random)
-    conventional: 5       # N for conventional
+    satellite: 30         # keep every N-th sample (stride); stride or keep ~1/N of samples uniformly (random)
+    conventional: 1       # N for conventional
     mode:
       satellite: "stride"      # "stride" | "random" | "none"
       conventional: "random"   # enable random for surface obs
@@ -11,10 +11,14 @@ pipeline:
 instrument_weights:
   atms: 1.0
   surface_obs: 1.0
+  amsua: 1.0
+  snow_cover: 1.0
 
 channel_weights:
   atms: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0] 
   surface_obs: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]   # one per predicted feature (6)
+  amsua: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+  snow_cover: [1.0, 1.0]            # snowDepth, snowWaterEquivalent
 
 observation_config:
   satellite:
@@ -31,114 +35,184 @@ observation_config:
       encoder_hidden_layers: 2
       decoder_hidden_layers: 2
 
-  conventional:
-    surface_obs:
-      source: nnja
-      dataframe_loader: my_loaders.load_adpsfc
-      time_col: OBS_TIMESTAMP
-      lat_col: LAT
-      lon_col: LON
-
-      var_map:
-        # pressure (adapter has fallback to PRSSQ1.PRES and auto Pa→hPa)
-        airPressure: PRESDATA.PRESSQ03.PRES
-        qm_airPressure: QMPR
-
-        # temperature (Kelvin in NC000101 → adapter converts to °C)
-        airTemperature: TEMHUMDA.TMDB
-        qm_airTemperature: QMAT
-
-        # dew point (adapter converts K→°C)
-        dewPointTemperature: TEMHUMDA.TMDP
-        qm_dewPointTemperature: QMDD
-
-        # humidity (as reported, %)
-        relativeHumidity: TEMHUMDA.REHU
-
-        # wind (speed & dir in NC000101; adapter computes wind_u, wind_v)
-        windSpeed: BSYWND1.WSPD
-        windDirection: BSYWND1.WDIR
-        qm_wind: QMWN
-
-        # metadata
-        height: SELV
-
-      # order here defines the target channel order everywhere (CSV, plotting, losses)
-      features: [airPressure, airTemperature, dewPointTemperature, relativeHumidity, wind_u, wind_v]
-      metadata: [height]
-      input_dim: 14  # input_dim  = 7 + len(metadata) + len(features)
-      target_dim: 6
+    amsua:
+      sat_ids: [3, 5, 206, 209, 223]
+      features: [bt_channel_1, bt_channel_2, bt_channel_3, bt_channel_4, bt_channel_5,
+                bt_channel_6, bt_channel_7, bt_channel_8, bt_channel_9, bt_channel_10,
+                bt_channel_11, bt_channel_12, bt_channel_13, bt_channel_14, bt_channel_15]
+      metadata: [sensorZenithAngle, solarZenithAngle, solarAzimuthAngle]
+      input_dim: 25
+      target_dim: 15
       encoder_hidden_layers: 2
       decoder_hidden_layers: 2
 
+  conventional:
+    surface_obs:
+      source: zarr
+      zarr_name: raw_surface_obs
+      features: [airPressure, airTemperature, dewPointTemperature, relativeHumidity, wind_u, wind_v]
+      metadata: [height]
+      input_dim: 14                      # 7 (geo/time enc) + 1 meta + 6 feats
+      target_dim: 6
+      encoder_hidden_layers: 2
+      decoder_hidden_layers: 2
       qc_filters:
         airPressure:
-          range: [300, 1200]       # hPa (adapter already converted Pa->hPa)
-          qm_flag_col: qm_airPressure
-          keep: [-1, 0, 1, 2, 4]            # -1=unknown/missing, 0=good, 2=Neutral or not checked, 1=probably good, 4=climo-ok
-
+          range: [300, 1200]
+          qm_flag_col: airPressureQuality_event_1
+          keep: [1,2,3,4]
         airTemperature:
-          range: [-80, 60]         # after K→°C conversion
-          qm_flag_col: qm_airTemperature
-          keep: [-1, 0, 1, 2, 4]
-
+          range: [-80, 60]
+          qm_flag_col: airTemperatureQuality_event_1
+          keep: [1,2,3,4]
         dewPointTemperature:
-          range: [-100, 40]                # °C (dew points)
-          qm_flag_col: qm_dewPointTemperature
-          keep: [-1, 0, 1, 2, 4]
-
+          range: [-100, 40]
+          qm_flag_col: dewPointTemperatureQuality_event_1
+          keep: [1,2,3,4]
         relativeHumidity:
-          range: [0, 100]                  # %
-          # NC000101 does not expose a dedicated RH QM; leave qm_flag_col unset or use temperature QC as a proxy.
-          # qm_flag_col: qm_airTemperature
-          keep: [-1, 0, 1, 2, 4]
+          range: [0, 100]
+        windSpeed:
+          range: [0, 75]
+        windDirection:
+          range: [0, 360]   # degrees
 
-        # wind components are signed m/s; use symmetric ranges
-        wind_u:
-          range: [-75, 75]                 # m/s
-          qm_flag_col: qm_wind
-          keep: [-1, 0, 1, 2, 4]
-        wind_v:
-          range: [-75, 75]                 # m/s
-          qm_flag_col: qm_wind
-          keep: [-1, 0, 1, 2, 4]
+    snow_cover:
+      source: zarr
+      zarr_name: snow_cover           # resolves to .../snow_cover.zarr
+      features: [snowDepth, snowWaterEquivalent]
+      metadata: []                    # none available in this Zarr
+      input_dim: 9                    # 7 geo/time + 0 meta + 2 feats
+      target_dim: 2
+      encoder_hidden_layers: 2
+      decoder_hidden_layers: 2
+      qc_filters:
+        # Basic physical ranges based on typical values
+        snowDepth:
+          range: [0.0, 10.0]          # meters (max ~6.83)
+        snowWaterEquivalent:
+          range: [0.0, 2000.0]        # mm (max ~1906)
+
+    # surface_obs:
+    #   source: nnja
+    #   dataframe_loader: my_loaders.load_adpsfc
+    #   time_col: OBS_TIMESTAMP
+    #   lat_col: LAT
+    #   lon_col: LON
+
+    #   var_map:
+    #     # pressure (adapter has fallback to PRSSQ1.PRES and auto Pa→hPa)
+    #     airPressure: PRESDATA.PRESSQ03.PRES
+    #     qm_airPressure: QMPR
+
+    #     # temperature (Kelvin in NC000101 → adapter converts to °C)
+    #     airTemperature: TEMHUMDA.TMDB
+    #     qm_airTemperature: QMAT
+
+    #     # dew point (adapter converts K→°C)
+    #     dewPointTemperature: TEMHUMDA.TMDP
+    #     qm_dewPointTemperature: QMDD
+
+    #     # humidity (as reported, %)
+    #     relativeHumidity: TEMHUMDA.REHU
+
+    #     # wind (speed & dir in NC000101; adapter computes wind_u, wind_v)
+    #     windSpeed: BSYWND1.WSPD
+    #     windDirection: BSYWND1.WDIR
+    #     qm_wind: QMWN
+
+    #     # metadata
+    #     height: SELV
+
+    #   # order here defines the target channel order everywhere (CSV, plotting, losses)
+    #   features: [airPressure, airTemperature, dewPointTemperature, relativeHumidity, wind_u, wind_v]
+    #   metadata: [height]
+    #   input_dim: 14  # input_dim  = 7 + len(metadata) + len(features)
+    #   target_dim: 6
+    #   encoder_hidden_layers: 2
+    #   decoder_hidden_layers: 2
+
+    #   qc_filters:
+    #     airPressure:
+    #       range: [300, 1200]       # hPa (adapter already converted Pa->hPa)
+    #       qm_flag_col: qm_airPressure
+    #       keep: [-1, 0, 1, 2, 4]            # -1=unknown/missing, 0=good, 2=Neutral or not checked, 1=probably good, 4=climo-ok
+
+    #     airTemperature:
+    #       range: [-80, 60]         # after K→°C conversion
+    #       qm_flag_col: qm_airTemperature
+    #       keep: [-1, 0, 1, 2, 4]
+
+    #     dewPointTemperature:
+    #       range: [-100, 40]                # °C (dew points)
+    #       qm_flag_col: qm_dewPointTemperature
+    #       keep: [-1, 0, 1, 2, 4]
+
+    #     relativeHumidity:
+    #       range: [0, 100]                  # %
+    #       # NC000101 does not expose a dedicated RH QM; leave qm_flag_col unset or use temperature QC as a proxy.
+    #       # qm_flag_col: qm_airTemperature
+    #       keep: [-1, 0, 1, 2, 4]
+
+    #     # wind components are signed m/s; use symmetric ranges
+    #     wind_u:
+    #       range: [-75, 75]                 # m/s
+    #       qm_flag_col: qm_wind
+    #       keep: [-1, 0, 1, 2, 4]
+    #     wind_v:
+    #       range: [-75, 75]                 # m/s
+    #       qm_flag_col: qm_wind
+    #       keep: [-1, 0, 1, 2, 4]
 
 feature_stats:  # Statistics for the features used in the model
-  airPressure: [972.39, 59.30]
-  airTemperature: [13.25, 11.96]
-  dewPointTemperature: [6.92, 10.92]
-  relativeHumidity: [71.06, 21.03]
-  wind_u: [0.24, 3.83]
-  wind_v: [0.26, 3.68]
-  latitude: [36.80, 6.44]
-  longitude: [-89.20, 9.75]
-  seaTemperature: [24.17, 5.62]
-  stationElevation: [381.52, 565.39]
-  virtualTemperature: [20.92, 8.51]
-  bt_channel_1: [259.20, 33.30]
-  bt_channel_2: [254.39, 39.29]
-  bt_channel_3: [266.43, 18.62]
-  bt_channel_4: [267.84, 11.89]
-  bt_channel_5: [264.40, 7.48]
-  bt_channel_6: [252.46, 6.54]
-  bt_channel_7: [236.02, 5.08]
-  bt_channel_8: [225.50, 3.65]
-  bt_channel_9: [218.70, 3.33]
-  bt_channel_10: [214.40, 4.22]
-  bt_channel_11: [217.72, 3.05]
-  bt_channel_12: [225.02, 2.63]
-  bt_channel_13: [234.56, 3.12]
-  bt_channel_14: [246.21, 3.41]
-  bt_channel_15: [255.89, 3.24]
-  bt_channel_16: [269.68, 20.06]
-  bt_channel_17: [276.82, 13.88]
-  bt_channel_18: [270.94, 11.07]
-  bt_channel_19: [265.76, 9.77]
-  bt_channel_20: [260.43, 8.85]
-  bt_channel_21: [253.80, 8.09]
-  bt_channel_22: [247.68, 7.61]
-  satelliteId: [225.02, 0.81]
-  sensorAzimuthAngle: [179.68, 94.52]
-  sensorZenithAngle: [31.15, 18.43]
-  solarAzimuthAngle: [125.22, 95.04]
-  solarZenithAngle: [71.94, 47.49]
+  surface_obs:
+    airPressure: [977.32, 57.51]
+    airTemperature: [17.0, 9.96]
+    dewPointTemperature: [10.39, 9.53]
+    relativeHumidity: [71.89, 20.25]
+    wind_u: [0.08, 4.17]
+    wind_v: [0.25, 3.37]
+    latitude: [30.06, 28.54]
+    longitude: [-22.73, 84.78]
+    stationElevation: [313.57, 506.03]
+  snow_cover:
+    snowDepth: [0.54, 0.77]
+    snowWaterEquivalent: [252.89, 285.5]
+  atms:
+    bt_channel_1: [259.20, 33.30]
+    bt_channel_2: [254.39, 39.29]
+    bt_channel_3: [266.43, 18.62]
+    bt_channel_4: [267.84, 11.89]
+    bt_channel_5: [264.40, 7.48]
+    bt_channel_6: [252.46, 6.54]
+    bt_channel_7: [236.02, 5.08]
+    bt_channel_8: [225.50, 3.65]
+    bt_channel_9: [218.70, 3.33]
+    bt_channel_10: [214.40, 4.22]
+    bt_channel_11: [217.72, 3.05]
+    bt_channel_12: [225.02, 2.63]
+    bt_channel_13: [234.56, 3.12]
+    bt_channel_14: [246.21, 3.41]
+    bt_channel_15: [255.89, 3.24]
+    bt_channel_16: [269.68, 20.06]
+    bt_channel_17: [276.82, 13.88]
+    bt_channel_18: [270.94, 11.07]
+    bt_channel_19: [265.76, 9.77]
+    bt_channel_20: [260.43, 8.85]
+    bt_channel_21: [253.80, 8.09]
+    bt_channel_22: [247.68, 7.61]
+  amsua:
+    bt_channel_1: [210.44, 42.44]
+    bt_channel_2: [202.56, 43.82]
+    bt_channel_3: [240.98, 21.74]
+    bt_channel_4: [253.28, 14.63]
+    bt_channel_5: [246.12, 11.41]
+    bt_channel_6: [231.76, 7.61]
+    bt_channel_7: [222.96, 5.97]
+    bt_channel_8: [216.95, 6.56]
+    bt_channel_9: [211.74, 8.73]
+    bt_channel_10: [214.12, 8.38]
+    bt_channel_11: [219.24, 9.86]
+    bt_channel_12: [227.0, 12.03]
+    bt_channel_13: [237.14, 13.31]
+    bt_channel_14: [247.58, 12.83]
+    bt_channel_15: [239.84, 28.86]

--- a/gnn_model/evaluations.py
+++ b/gnn_model/evaluations.py
@@ -299,12 +299,32 @@ if __name__ == "__main__":
         drop_small_truth=True,
     )
 
+    plot_instrument_maps(
+        "snow_cover",
+        EPOCH_TO_PLOT,
+        BATCH_IDX_TO_PLOT,
+        num_channels=2,
+        data_dir="val_csv",
+        error_metric="auto",
+        drop_small_truth=True,
+    )
+
     # ATMS: keep % error (symmetric color scale around 0)
     plot_instrument_maps(
         "atms",
         EPOCH_TO_PLOT,
         BATCH_IDX_TO_PLOT,
         num_channels=22,
+        data_dir="val_csv",
+        error_metric="percent",
+        drop_small_truth=False,
+    )
+
+    plot_instrument_maps(
+        "amsua",
+        EPOCH_TO_PLOT,
+        BATCH_IDX_TO_PLOT,
+        num_channels=15,
         data_dir="val_csv",
         error_metric="percent",
         drop_small_truth=False,

--- a/gnn_model/gnn_datamodule.py
+++ b/gnn_model/gnn_datamodule.py
@@ -28,6 +28,7 @@ class BinDataset(Dataset):
         zarr_store,
         create_graph_fn,
         observation_config,
+        feature_stats=None,
         apply_masking=True,
     ):
         self.bin_names = bin_names
@@ -35,6 +36,7 @@ class BinDataset(Dataset):
         self.z = zarr_store
         self.create_graph_fn = create_graph_fn
         self.observation_config = observation_config
+        self.feature_stats = feature_stats
         self.apply_masking = apply_masking
 
     def __len__(self):
@@ -45,7 +47,7 @@ class BinDataset(Dataset):
         rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
         print(f"[Rank {rank}] Fetching {bin_name}...")
         try:
-            bin_data = extract_features(self.z, self.data_summary, bin_name, self.observation_config)[bin_name]
+            bin_data = extract_features(self.z, self.data_summary, bin_name, self.observation_config, feature_stats=self.feature_stats)[bin_name]
             graph_data = self.create_graph_fn(bin_data)
             graph_data.bin_name = bin_name
             return graph_data
@@ -64,11 +66,13 @@ class GNNDataModule(pl.LightningDataModule):
         mesh_structure,
         batch_size=1,
         num_neighbors=3,
+        feature_stats=None,
         **kwargs,
     ):
         super().__init__()
         self.save_hyperparameters()
         self.mesh_structure = mesh_structure
+        self.feature_stats = feature_stats
         self.z = None
         self.data_summary = None
         self.train_bin_names = None
@@ -83,8 +87,28 @@ class GNNDataModule(pl.LightningDataModule):
                     src = inst_cfg.get("source", "zarr")
 
                     if src == "zarr":
-                        zarr_path = os.path.join(self.hparams.data_path, inst_name) + ".zarr"
+                        zarr_dir = inst_cfg.get("zarr_dir")  # full path override (absolute or relative)
+                        if zarr_dir:
+                            zarr_path = zarr_dir
+                        else:
+                            zname = inst_cfg.get("zarr_name", inst_name)  # basename or basename.zarr
+                            if not zname.endswith(".zarr"):
+                                zname += ".zarr"
+                            zarr_path = os.path.join(self.hparams.data_path, zname)
+
+                        if not os.path.isdir(zarr_path):
+                            raise FileNotFoundError(f"Conventional Zarr not found: {zarr_path}")
                         self.z[obs_type][inst_name] = zarr.open(LRUStoreCache(zarr.DirectoryStore(zarr_path), max_size=2e9), mode="r")
+                        rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+                        if rank == 0:
+                            print(f"[ZARR] {obs_type}/{inst_name} -> {zarr_path}")
+                            print("  has keys:", list(self.z[obs_type][inst_name].keys())[:12])
+
+                        # Optional guard to ensure the right file is used for surface_obs
+                        if obs_type == "conventional" and inst_name == "surface_obs":
+                            if not os.path.basename(zarr_path).startswith("raw_surface_obs"):
+                                print(f"[WARN] surface_obs expected raw_surface_obs*.zarr but got: {zarr_path}")
+
                     elif src == "nnja":
                         # Load DataFrame via dotted loader path
                         loader_path = inst_cfg["dataframe_loader"]
@@ -115,6 +139,7 @@ class GNNDataModule(pl.LightningDataModule):
             self.hparams.start_date,
             self.hparams.end_date,
             self.hparams.observation_config,
+            pipeline_cfg=self.hparams.pipeline,
         )
         all_bin_names = sorted(list(self.data_summary.keys()), key=lambda x: int(x.replace("bin", "")))
 
@@ -128,6 +153,7 @@ class GNNDataModule(pl.LightningDataModule):
                 self.z,
                 self._create_graph_structure,
                 self.hparams.observation_config,
+                feature_stats=self.feature_stats,
                 apply_masking=True,
             )
 
@@ -165,13 +191,17 @@ class GNNDataModule(pl.LightningDataModule):
 
                     # --- TARGET NODES & EDGES ---
                     target_features = inst_data["target_features_final"]
-                    if inst_name == "atms":
-                        data[node_type_target].y = target_features  # [N, 22]
+                    if inst_name in ("atms", "amsua"):
+                        data[node_type_target].y = target_features  # [N, target_dim]
                         data[node_type_target].x = inst_data["scan_angle"].to(torch.float32)  # [N, 1]
                         # instrument IDs (long)
                         inst_id = int(inst_data["instrument_id"])
                         num_nodes = target_features.shape[0]
                         data[node_type_target].instrument_ids = torch.full((num_nodes,), inst_id, dtype=torch.long)
+                        if "target_channel_mask" in inst_data:
+                            data[node_type_target].target_channel_mask = inst_data["target_channel_mask"].to(torch.bool)
+                        else:
+                            data[node_type_target].target_channel_mask = torch.ones_like(target_features, dtype=torch.bool)
                     else:
                         # For other obs, all features are targets in '.y'
                         data[node_type_target].y = target_features  # [N, target_dim]
@@ -234,7 +264,7 @@ class GNNDataModule(pl.LightningDataModule):
             shuffle=True,
             num_workers=4,
             pin_memory=True,
-            persistent_workers=True,
+            persistent_workers=False,
         )
 
     def val_dataloader(self):
@@ -246,6 +276,7 @@ class GNNDataModule(pl.LightningDataModule):
             self.z,
             self._create_graph_structure,
             self.hparams.observation_config,
+            feature_stats=self.feature_stats,
             apply_masking=False,
         )
         return PyGDataLoader(

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -22,6 +22,14 @@ from torch_geometric.utils import scatter
 from loss import weighted_huber_loss
 
 
+def _build_instrument_map(observation_config: dict) -> dict[str, int]:
+    order = []
+    for group in ("satellite", "conventional"):
+        if group in observation_config:
+            order += sorted(observation_config[group].keys())
+    return {name: i for i, name in enumerate(order)}
+
+
 class GNNLightning(pl.LightningModule):
     """
     A Graph Neural Network (GNN) model for processing structured spatiotemporal data.
@@ -69,19 +77,25 @@ class GNNLightning(pl.LightningModule):
         self.lr = lr
         self.instrument_weights = instrument_weights or {}
         self.channel_weights = channel_weights or {}
-        self.channel_masks = {}
-        for inst_id, weights in self.channel_weights.items():
-            if isinstance(weights, torch.Tensor):
-                weights_tensor = weights.clone().detach()
-            else:
-                weights_tensor = torch.tensor(weights)
-            mask = weights_tensor > 0
-            self.channel_masks[int(inst_id)] = mask
         self.max_rollout_steps = max_rollout_steps
         self.rollout_schedule = rollout_schedule
 
         self.observation_config = observation_config
-        self.instrument_name_to_id = {"atms": 0, "surface_obs": 1, "radiosonde": 2}
+        # Mirror process_timeseries._name2id()
+        self.instrument_name_to_id = _build_instrument_map(self.observation_config)
+        self.instrument_id_to_name = {v: k for k, v in self.instrument_name_to_id.items()}
+
+        # Normalize user-provided weights (accept names or ids)
+        self.instrument_weights = self._normalize_inst_weights(instrument_weights)
+        self.channel_weights = self._normalize_channel_weights(channel_weights)
+
+        # Boolean masks per instrument for valid channels (weights > 0)
+        self.channel_masks = {inst_id: (w > 0) for inst_id, w in self.channel_weights.items()}
+
+        if self.verbose:
+            print("[MODEL] instrument map:", self.instrument_name_to_id)
+            print("[MODEL] instrument_weights:", {self.instrument_id_to_name[k]: float(v) for k, v in self.instrument_weights.items()})
+
         self.hidden_dim = hidden_dim
 
         # --- Create and store the mesh structure as part of the model ---
@@ -141,15 +155,16 @@ class GNNLightning(pl.LightningModule):
                 # Initial MLP to project raw features to hidden_dim
                 self.observation_embedders[node_type_input] = make_mlp([input_dim] + self.mlp_blueprint_end)
 
-                # Final MLP to map from hidden dim to output dim
-                if node_type_target == "atms_target":
-                    self.scan_angle_embed_dim = 8
+                # Final MLP: add scan-angle embedder for ATMS & AMSU-A targets
+                has_aux = node_type_target in ("atms_target", "amsua_target")
+                if has_aux:
+                    self.scan_angle_embed_dim = 8  # reuse for both
+                    # make a per-target embedder dict if you prefer, but one works since both are 1D -> 8D
                     self.scan_angle_embedder = make_mlp([1, self.scan_angle_embed_dim])
                     input_dim_for_mapper = hidden_dim + self.scan_angle_embed_dim
                 else:
                     input_dim_for_mapper = hidden_dim
 
-                # Add one more hidden layer to the output mapper as requested
                 output_map_layers = [input_dim_for_mapper] + [hidden_dim] * hidden_layers + [target_dim]
                 self.output_mappers[node_type_target] = make_mlp(output_map_layers, layer_norm=False)
 
@@ -173,6 +188,53 @@ class GNNLightning(pl.LightningModule):
         self.register_buffer("mesh_x", _as_f32(mesh_x))
         self.register_buffer("mesh_edge_index", _as_i64(mesh_edge_index))
         self.register_buffer("mesh_edge_attr", _as_f32(mesh_edge_attr))
+
+    def _normalize_inst_weights(self, weights_in):
+        out = {}
+        if not weights_in:
+            return out
+        for k, v in weights_in.items():
+            if isinstance(k, str):
+                if k in self.instrument_name_to_id:
+                    out[self.instrument_name_to_id[k]] = float(v)
+            else:
+                out[int(k)] = float(v)
+        return out
+
+    def _normalize_channel_weights(self, ch_in):
+        """
+        Accepts {name_or_id: sequence/tensor} and returns {id: torch.tensor}
+        sized to that instrument's target_dim (slice/pad with 1.0 as needed).
+        """
+        out = {}
+        if not ch_in:
+            return out
+        for k, v in ch_in.items():
+            # resolve id and name
+            if isinstance(k, str):
+                if k not in self.instrument_name_to_id:
+                    continue
+                inst_name, inst_id = k, self.instrument_name_to_id[k]
+            else:
+                inst_id = int(k)
+                inst_name = getattr(self, "instrument_id_to_name", {}).get(inst_id, None)
+
+            # find expected target_dim from config
+            target_dim = None
+            for group, instruments in self.observation_config.items():
+                if inst_name in instruments:
+                    target_dim = instruments[inst_name]["target_dim"]
+                    break
+            if target_dim is None:
+                continue
+
+            w = torch.as_tensor(v, dtype=torch.float32)
+            if w.numel() > target_dim:
+                w = w[:target_dim]
+            elif w.numel() < target_dim:
+                w = torch.cat([w, torch.ones(target_dim - w.numel(), dtype=torch.float32)], dim=0)
+            out[inst_id] = w
+        return out
 
     def _feature_names_for_node(self, node_type: str):
         """Return ordered feature names for this target node."""
@@ -208,53 +270,80 @@ class GNNLightning(pl.LightningModule):
 
     def unnormalize_standardscaler(self, tensor, node_type, mean=None, std=None):
         """
-        Undo standardization (z-score) for predictions/targets.
+        Reverse a per-channel standardization: x = x * std + mean.
 
-        - If node_type is "atms_target": uses bt_channel_1..22 from feature_stats.
-        - If node_type is "surface_obs_target": uses feature order defined in observation_config["surface_obs"]["features"].
-        - Otherwise raises ValueError.
+        - If `mean` and `std` are provided, they are used directly.
+        - Otherwise we look up the instrument from `node_type` (expects "<instrument>_target"),
+        get the feature order from `self.observation_config`, and pull means/stds
+        from `self.feature_stats[instrument][feature] = [mean, std]`.
+
+        Args:
+            tensor:  (..., C) torch.Tensor — standardized values
+            node_type: str — e.g., "atms_target", "amsua_target", "surface_obs_target", "snow_cover_target"
+            mean, std: optional sequences/ndarrays/torch tensors of shape (C,)
+
+        Returns:
+            torch.Tensor with the same shape as `tensor`, un-normalized per channel.
         """
-        if node_type == "atms_target":
-            features = [f"bt_channel_{i}" for i in range(1, 23)]
-            mean_vec = torch.tensor(
-                [self.feature_stats[f][0] for f in features],
-                dtype=torch.float32,
-                device=self.device,
-            )
-            std_vec = torch.tensor(
-                [self.feature_stats[f][1] for f in features],
-                dtype=torch.float32,
-                device=self.device,
-            )
-            return tensor * std_vec + mean_vec
+        # If explicit stats are provided, use them
+        if mean is not None and std is not None:
+            device = tensor.device if torch.is_tensor(tensor) else getattr(self, "device", "cpu")
+            dtype = tensor.dtype if torch.is_tensor(tensor) else torch.float32
+            mean = torch.as_tensor(mean, dtype=dtype, device=device)
+            std = torch.as_tensor(std, dtype=dtype, device=device)
+            return tensor * std + mean
 
-        elif node_type == "surface_obs_target":
-            # Find the configured features for surface_obs
-            feats = None
-            for obs_type, instruments in self.observation_config.items():
-                if "surface_obs" in instruments:
-                    feats = instruments["surface_obs"]["features"]
-                    break
-            if feats is None:
-                raise ValueError("surface_obs config with 'features' not found for unnormalization")
+        # Parse "<instrument>_target" (also tolerate "<instrument>_input" just in case)
+        if not isinstance(node_type, str) or "_" not in node_type:
+            raise ValueError(f"node_type must look like '<instrument>_target', got: {node_type!r}")
+        inst_name = node_type.rsplit("_", 1)[0]  # drop trailing _target/_input/etc.
 
-            # Build mean/std vectors for the configured order
-            mean_vec = torch.tensor(
-                [self.feature_stats[f][0] for f in feats],
-                dtype=torch.float32,
-                device=self.device,
-            )
-            std_vec = torch.tensor(
-                [self.feature_stats[f][1] for f in feats],
-                dtype=torch.float32,
-                device=self.device,
-            )
+        # Find instrument block and feature order from the config
+        feats = None
+        found_in_obs_type = None
+        for obs_type, instruments in self.observation_config.items():
+            if inst_name in instruments:
+                feats = instruments[inst_name].get("features")
+                found_in_obs_type = obs_type
+                break
+        if not feats:
+            raise ValueError(f"Features for instrument '{inst_name}' not found in observation_config.")
 
-            # Broadcast to prediction shape if needed
-            return tensor * std_vec + mean_vec
+        # Pull stats for this instrument
+        if not hasattr(self, "feature_stats") or self.feature_stats is None:
+            raise ValueError("self.feature_stats is not set; cannot unnormalize without stats.")
 
+        if inst_name not in self.feature_stats:
+            # Some configs store stats under category keys; try a second chance lookup
+            cand = self.feature_stats.get(found_in_obs_type, {})
+            if inst_name in cand:
+                stats_block = cand[inst_name]
+            else:
+                raise KeyError(f"feature_stats has no entry for instrument '{inst_name}'.")
         else:
-            raise ValueError(f"Un-normalization not supported for node_type: {node_type}")
+            stats_block = self.feature_stats[inst_name]
+
+        # Build mean/std vectors following the feature order exactly
+        try:
+            mean_vec = [stats_block[f][0] for f in feats]
+            std_vec = [stats_block[f][1] for f in feats]
+        except KeyError as e:
+            missing = str(e).strip("'")
+            raise KeyError(f"Missing statistics for '{inst_name}.{missing}'. " f"Expected keys: {feats}. Have: {list(stats_block.keys())}") from e
+
+        device = tensor.device if torch.is_tensor(tensor) else getattr(self, "device", "cpu")
+        dtype = tensor.dtype if torch.is_tensor(tensor) else torch.float32
+        mean_vec = torch.tensor(mean_vec, dtype=dtype, device=device)
+        std_vec = torch.tensor(std_vec, dtype=dtype, device=device)
+
+        # Basic shape check: last dim must match number of features
+        if tensor.size(-1) != mean_vec.numel():
+            raise ValueError(
+                f"Channel mismatch for '{inst_name}': tensor last-dim={tensor.size(-1)} "
+                f"but have {mean_vec.numel()} feature stats. Feature order={feats}"
+            )
+
+        return tensor * std_vec + mean_vec
 
     def forward(self, data: HeteroData, step_data_list=None) -> Dict[str, torch.Tensor]:
 
@@ -288,7 +377,7 @@ class GNNLightning(pl.LightningModule):
             src_type, _, dst_type = edge_type
             if dst_type == "mesh" and src_type != "mesh":  # This is an obs -> mesh edge
                 obs_features = embedded_features[src_type]
-                edge_attr = torch.empty((edge_index.size(1), self.hidden_dim), device=self.device)
+                edge_attr = torch.zeros((edge_index.size(1), self.hidden_dim), device=self.device)
 
                 encoder = self.observation_encoders[self._edge_key(edge_type)]
                 encoder.edge_index = edge_index
@@ -338,7 +427,7 @@ class GNNLightning(pl.LightningModule):
                 decoder = self.observation_decoders[self._edge_key(edge_type)]
                 decoder.edge_index = edge_index
 
-                edge_attr = torch.empty((edge_index.size(1), self.hidden_dim), device=self.device)
+                edge_attr = torch.zeros((edge_index.size(1), self.hidden_dim), device=self.device)
 
                 decoded_target_features = decoder(
                     send_rep=mesh_features_processed,
@@ -346,7 +435,7 @@ class GNNLightning(pl.LightningModule):
                     edge_rep=edge_attr,
                 )
 
-                if dst_type == "atms_target":
+                if dst_type in ("atms_target", "amsua_target"):
                     scan_angle = data[dst_type].x
                     scan_angle_embedded = self.scan_angle_embedder(scan_angle)
                     final_features = torch.cat([decoded_target_features, scan_angle_embedded], dim=-1)
@@ -535,6 +624,16 @@ class GNNLightning(pl.LightningModule):
 
                 instrument_ids = step_data_list[step].get(node_type, {}).get("instrument_ids", None)
                 valid_mask = step_data_list[step].get(node_type, {}).get("target_channel_mask", None)
+                # Ensure finite tensors
+                if not torch.isfinite(y_pred).all():
+                    y_pred = torch.nan_to_num(y_pred, nan=0.0, posinf=0.0, neginf=0.0)
+                if not torch.isfinite(y_true).all():
+                    y_true = torch.nan_to_num(y_true, nan=0.0, posinf=0.0, neginf=0.0)
+
+                # Skip if mask exists but nothing valid
+                if valid_mask is not None and valid_mask.sum() == 0:
+                    continue
+
                 channel_loss = weighted_huber_loss(
                     y_pred,
                     y_true,
@@ -544,6 +643,11 @@ class GNNLightning(pl.LightningModule):
                     rebalancing=True,
                     valid_mask=valid_mask,
                 )
+
+                if not torch.isfinite(channel_loss):
+                    if self.trainer.is_global_zero:
+                        print(f"[WARN] Non-finite channel_loss for {node_type} at step {step}; skipping this term.")
+                    continue
 
                 # Apply the overall instrument weight
                 weighted_loss = channel_loss * instrument_weight

--- a/gnn_model/process_timeseries.py
+++ b/gnn_model/process_timeseries.py
@@ -55,7 +55,7 @@ def _stable_seed(seed_base: int, bin_time: pd.Timestamp, obs_type: str, key: str
 
 
 @timing_resource_decorator
-def organize_bins_times(z_dict, start_date, end_date, observation_config, window_size="12h", verbose=False):
+def organize_bins_times(z_dict, start_date, end_date, observation_config, pipeline_cfg=None, window_size="12h", verbose=False):
     """
     Bin definition: a bin consists of a pair of input and targets, each covers window_size.
     Organizes observation times into time bins and creates input-target pairs.
@@ -82,7 +82,7 @@ def organize_bins_times(z_dict, start_date, end_date, observation_config, window
         raise ValueError("window_size must end with 'h' (e.g., '6h', '12h').")
 
     # subsampling config
-    subs_cfg = observation_config.get("pipeline", {}).get("subsample", {}) or {}
+    subs_cfg = (pipeline_cfg or {}).get("subsample", {}) or {}
     delta_satellite = int(subs_cfg.get("satellite", 25))
     delta_surface = int(subs_cfg.get("conventional", 20))
     mode_cfg = subs_cfg.get("mode", {}) or {}
@@ -173,8 +173,23 @@ def organize_bins_times(z_dict, start_date, end_date, observation_config, window
     return data_summary
 
 
+def _name2id(observation_config):
+    order = []
+    for obs_type in ("satellite", "conventional"):
+        if obs_type in observation_config:
+            order += sorted(observation_config[obs_type].keys())
+    return {name: i for i, name in enumerate(order)}
+
+
+# Helper that returns an empty (N,0) if there are no keys
+def _stack_or_empty(arrs, keys, idx):
+    if not keys:
+        return np.empty((len(idx), 0), dtype=np.float32)
+    return np.column_stack([arrs[k][idx] for k in keys]).astype(np.float32)
+
+
 @timing_resource_decorator
-def extract_features(z_dict, data_summary, bin_name, observation_config):
+def extract_features(z_dict, data_summary, bin_name, observation_config, feature_stats=None):
     """
     Loads and normalizes input and target features for each time bin individually.
     Adds per-channel masks for conventional targets so features can be missing independently.
@@ -182,6 +197,7 @@ def extract_features(z_dict, data_summary, bin_name, observation_config):
     print(f"\nProcessing {bin_name}...")
     for obs_type in list(data_summary[bin_name].keys()):
         for inst_name in list(data_summary[bin_name][obs_type].keys()):
+            target_channel_mask = None
             z = z_dict[obs_type][inst_name]
 
             data_summary_bin = data_summary[bin_name][obs_type][inst_name]
@@ -247,14 +263,30 @@ def extract_features(z_dict, data_summary, bin_name, observation_config):
             feat_keys = observation_config[obs_type][inst_name]["features"]
             meta_keys = observation_config[obs_type][inst_name]["metadata"]
 
-            input_features_raw = np.column_stack([z[k][input_idx] for k in feat_keys]).astype(np.float32)
-            input_metadata_raw = np.column_stack([z[k][input_idx] for k in meta_keys]).astype(np.float32)
+            # Helper: fetch a feature, with fallbacks/derived transforms for conventional wind
+            def _get_feature(arrs, name, idx):
+                if name in arrs:
+                    return arrs[name][idx]
+                if name in ("wind_u", "wind_v") and ("windSpeed" in arrs and "windDirection" in arrs):
+                    ws = arrs["windSpeed"][idx].astype(np.float32)
+                    wd = arrs["windDirection"][idx].astype(np.float32)
+                    # auto-detect units: if values are mostly > 2π, treat as degrees
+                    # (use nanmax to avoid NaNs; add small margin)
+                    wd_rad = wd if np.nanmax(wd) <= (2 * np.pi + 0.1) else wd * (np.pi / 180.0)
+                    # Meteorological convention: direction is the FROM direction.
+                    u = -ws * np.sin(wd_rad)
+                    v = -ws * np.cos(wd_rad)
+                    return u if name == "wind_u" else v
+                raise KeyError(f"Requested feature '{name}' not found in Zarr and no fallback rule defined.")
+
+            input_features_raw = np.column_stack([_get_feature(z, k, input_idx) for k in feat_keys]).astype(np.float32)
+            input_metadata_raw = _stack_or_empty(z, meta_keys, input_idx)
             input_lat_raw = z["latitude"][input_idx]
             input_lon_raw = z["longitude"][input_idx]
             input_times_raw = z["time"][input_idx]
 
-            target_features_raw = np.column_stack([z[k][target_idx] for k in feat_keys]).astype(np.float32)
-            target_metadata_raw = np.column_stack([z[k][target_idx] for k in meta_keys]).astype(np.float32)
+            target_features_raw = np.column_stack([_get_feature(z, k, target_idx) for k in feat_keys]).astype(np.float32)
+            target_metadata_raw = _stack_or_empty(z, meta_keys, target_idx)
             target_lat_raw = z["latitude"][target_idx]
             target_lon_raw = z["longitude"][target_idx]
             target_times_raw = z["time"][target_idx]
@@ -340,6 +372,7 @@ def extract_features(z_dict, data_summary, bin_name, observation_config):
                 input_metadata_rad = np.deg2rad(input_metadata_raw)
                 input_metadata_cos = np.cos(input_metadata_rad)
                 input_metadata = input_metadata_cos
+
                 # Normalize target metadata angles for the decoder
                 target_metadata_rad = np.deg2rad(target_metadata_raw)
                 target_metadata_cos = np.cos(target_metadata_rad)
@@ -357,28 +390,49 @@ def extract_features(z_dict, data_summary, bin_name, observation_config):
                         input_features_norm,
                     ]
                 )
-                scan_angle = target_metadata_cos[:, 0:1]
-                target_features_final = target_features_norm
+
+                # ---- per-channel mask for satellite targets + NaN-safe target features ----
+                target_channel_mask = ~np.isnan(target_features_norm)  # [N, C]
+                target_features_final = np.nan_to_num(target_features_norm, nan=0.0).astype(np.float32)
+
+                scan_angle = target_metadata_cos[:, 0:1]  # cos(sensorZenithAngle)
                 target_metadata = np.column_stack([lat_rad_target, lon_rad_target, target_metadata_cos])
 
             else:
-                # --------- CONVENTIONAL: NaN-safe per-channel standardization + mask ---------
-                # Compute per-channel mean/std over combined input+target, ignoring NaNs in target
-                combined = np.vstack([input_features_raw, target_features_raw])  # may include NaNs (from target)
-                means = np.nanmean(combined, axis=0)
-                stds = np.nanstd(combined, axis=0)
+                # --------- CONVENTIONAL: use global stats if provided; else fallback to per-bin ---------
+                # Try global (YAML) stats first, keyed by instrument name and ordered by feat_keys
+                means = stds = None
+                if feature_stats is not None and inst_name in feature_stats:
+                    try:
+                        means = np.array([feature_stats[inst_name][k][0] for k in feat_keys], dtype=np.float32)
+                        stds = np.array([feature_stats[inst_name][k][1] for k in feat_keys], dtype=np.float32)
+                    except KeyError as e:
+                        raise KeyError(f"Missing stat for {inst_name}.{e}") from e
+
+                # Fallback: per-bin stats (ignore NaNs in targets)
+                if means is None or stds is None:
+                    combined = np.vstack([input_features_raw, target_features_raw])  # targets may include NaNs
+                    means = np.nanmean(combined, axis=0).astype(np.float32)
+                    stds = np.nanstd(combined, axis=0).astype(np.float32)
+
+                # Guard degenerate stats
                 stds[(stds == 0) | ~np.isfinite(stds)] = 1.0
                 means[~np.isfinite(means)] = 0.0
 
-                # Standardize
+                # Standardize (preserve NaNs in targets for channel masks)
                 input_features_norm = (input_features_raw - means) / stds
-                target_features_norm = (target_features_raw - means) / stds  # NaNs preserved here
+                target_features_norm = (target_features_raw - means) / stds  # keep NaNs
 
-                # Metadata normalization (unchanged)
-                features_scaler = StandardScaler()
-                input_metadata_norm = features_scaler.fit_transform(input_metadata_raw)
-                target_scaler = StandardScaler()
-                target_metadata_norm = target_scaler.fit_transform(target_metadata_raw)
+                # Metadata normalization (per-bin; guard empty)
+                if input_metadata_raw.shape[1] > 0:
+                    input_metadata_norm = StandardScaler().fit_transform(input_metadata_raw)
+                else:
+                    input_metadata_norm = np.empty((input_metadata_raw.shape[0], 0), dtype=np.float32)
+
+                if target_metadata_raw.shape[1] > 0:
+                    target_metadata_norm = StandardScaler().fit_transform(target_metadata_raw)
+                else:
+                    target_metadata_norm = np.empty((target_metadata_raw.shape[0], 0), dtype=np.float32)
 
                 # Final input features for conventional
                 input_metadata = input_metadata_norm
@@ -398,7 +452,6 @@ def extract_features(z_dict, data_summary, bin_name, observation_config):
 
                 # ---- Build target mask BEFORE filling NaNs ----
                 target_channel_mask = ~np.isnan(target_features_norm)  # shape [N, C]
-                # Replace NaNs with 0 AFTER standardization to keep tensor dense
                 target_features_final = np.nan_to_num(target_features_norm, nan=0.0).astype(np.float32)
 
                 # Target metadata for plotting
@@ -420,13 +473,11 @@ def extract_features(z_dict, data_summary, bin_name, observation_config):
             data_summary_bin["target_lat_deg"] = z["latitude"][target_idx]
             data_summary_bin["target_lon_deg"] = z["longitude"][target_idx]
 
-            NAME2ID = {"atms": 0, "surface_obs": 1, "radiosonde": 2}
+            NAME2ID = _name2id(observation_config)
             data_summary_bin["instrument_id"] = NAME2ID[inst_name]
 
-            # Add per-channel mask ONLY for conventional (surface_obs/radiosonde)
-            if obs_type != "satellite":
-                # Ensure boolean torch tensor
-                data_summary_bin["target_channel_mask"] = torch.tensor(target_channel_mask.astype(bool), dtype=torch.bool)
+            # satellite or conventional branch sets target_channel_mask
+            data_summary_bin["target_channel_mask"] = torch.tensor(target_channel_mask.astype(bool), dtype=torch.bool)
 
             print(f"[{bin_name}] input_features_final shape: {input_features_final.shape}")
             print(f"[{bin_name}] target_features_final shape: {target_features_final.shape}")

--- a/gnn_model/train_gnn.py
+++ b/gnn_model/train_gnn.py
@@ -56,6 +56,10 @@ def main():
     # === DATA & MODEL CONFIGURATION ===
     cfg_path = "configs/observation_config.yaml"
     observation_config, feature_stats, instrument_weights, channel_weights, name_to_id = load_weights_from_yaml(cfg_path)
+    # grab top-level pipeline from the same YAML
+    with open(cfg_path, "r") as f:
+        _raw_cfg = yaml.safe_load(f)
+    pipeline_cfg = _raw_cfg.get("pipeline", {})
 
     # Data/region path
     region = "global"
@@ -67,7 +71,7 @@ def main():
     # --- DEFINE THE FULL DATE RANGE FOR THE EXPERIMENT ---
     FULL_START_DATE = "2024-04-01"
     FULL_END_DATE = "2024-07-01"  # e.g., 3 months of data
-    WINDOW_DAYS = 14  # The size of the window for each epoch
+    WINDOW_DAYS = 7  # The size of the window for each epoch
 
     # The initial start/end dates for the datamodule are the
     # first window of the full period. The callback will change this on subsequent epochs.
@@ -77,7 +81,7 @@ def main():
     # --- HYPERPARAMETERS ---
     mesh_resolution = 6
     hidden_dim = 64
-    num_layers = 10
+    num_layers = 8
     lr = 0.001
     max_epochs = 100
     batch_size = 1
@@ -111,6 +115,8 @@ def main():
         mesh_structure=model.mesh_structure,
         batch_size=batch_size,
         num_neighbors=3,
+        feature_stats=feature_stats,
+        pipeline=pipeline_cfg,
     )
 
     is_main_process = os.environ.get("SLURM_PROCID", "0") == "0"
@@ -154,7 +160,7 @@ def main():
         process_group_backend="nccl",
         find_unused_parameters=False,
         gradient_as_bucket_view=True,
-        timeout=timedelta(minutes=45),
+        timeout=timedelta(minutes=15),
     )
     trainer_kwargs = {
         "max_epochs": max_epochs,

--- a/gnn_model/weight_utils.py
+++ b/gnn_model/weight_utils.py
@@ -1,7 +1,7 @@
 import yaml
 import torch
 
-INSTRUMENT_NAME_TO_ID = {"atms": 0, "surface_obs": 1, "radiosonde": 2}
+INSTRUMENT_NAME_TO_ID = {"atms": 0, "surface_obs": 1, "amsua": 2, "snow_cover": 3}
 
 
 def load_weights_from_yaml(path):


### PR DESCRIPTION
This PR integrates three new data streams and the supporting plumbing across data prep, normalization, masking, and graph construction.

### Highlights

- **AMSUA**
  - Added satellite/amsua to observation_config with 15 BT channels and zenith/solar metadata.
  - Per-bin StandardScaler for satellite inputs/targets; cosine-encoded angle metadata.
  - Decoder uses scan_angle = cos(sensorZenithAngle) as aux input.

- **Raw surface observations (ADPSFC/SFCSHP/PREPBUFR)**

  - Added conventional/surface_obs reading from raw_surface_obs.zarr.
  - QC: range checks + BUFR Quality_event code filters
  - Wind derivation: build wind_u, wind_v from windSpeed/windDirection with auto rad/deg detection.
  - NaN-safe standardization: per-channel mean/std (global from config if available, else per-bin), preserving NaNs in targets.
  - Per-channel target masks (target_channel_mask) so loss ignores missing channels.

- **Snow cover**

  - Added conventional/snow_cover with snowDepth (m) and snowWaterEquivalent (mm).
  - Basic physical QC ranges; zero metadata case supported.
  - Included feature stats and channel/instrument weights.

### Core changes

- **Timeseries processing**
  - `extract_features(...)` now accepts `feature_stats` and uses config-provided means/stds for conventional streams; falls back to per-bin stats.
  - Replaces fill values with NaN, filters on metadata for targets, builds per-channel masks before filling NaNs.
  - Satellite: joint fit scaler on input+target per bin; angle metadata normalized via cos(·); scan_angle exported.
  - Stable, per-bin subsampling with stride/random modes and deterministic seeds (Blake2b hash).
  - Helper _get_feature(...) with wind component fallback; _stack_or_empty(...) for empty metadata.

- **DataModule**
  - Robust Zarr loader with LRUStoreCache; prints keys and warns if surface_obs isn’t raw_surface_obs*.zarr.
  - Passes feature_stats through to extract_features (fixed a missing/duplicate kwarg bug).
  - Graph builder attaches instrument_ids, target_channel_mask, decoder aux (scan_angle for sats), and positions.

- **Model utils**
  - Generalized unnormalize_standardscaler(...) to map any *_target node to its feature list and use feature_stats from config (supports atms, amsua, surface_obs, snow_cover, and future instruments).

- **Stats & plots**
  - Added scripts/logic to compute and serialize feature stats for surface_obs and snow_cover.
  - Utility to plot raw 12-hour snow windows for snowDepth/SWE QA.