### PR TITLE
v7 data migration + SEVIRI asr/csr split + FSOI empty-graph robustness

### DIFF
--- a/gnn_model/FSOI/configs/fsoi_config_radiosonde_all.yaml
+++ b/gnn_model/FSOI/configs/fsoi_config_radiosonde_all.yaml
@@ -65,7 +65,8 @@ memory:
     atms: 50000
     amsua: 30000
     ssmis: 30000
-    seviri: 30000
+    seviri_asr: 30000
+    seviri_csr: 30000
 
 model:
   checkpoint_path: "checkpoints/"

--- a/gnn_model/FSOI/configs/fsoi_config_radiosonde_temp.yaml
+++ b/gnn_model/FSOI/configs/fsoi_config_radiosonde_temp.yaml
@@ -80,7 +80,8 @@ memory:
     atms: 50000     # raw ~200k  → 50k
     amsua: 30000    # raw ~30k   → 30k (usually already small, extra safety)
     ssmis: 30000    # raw ~50k   → 30k
-    seviri: 30000   # raw ~36k   → 30k
+    seviri_asr: 30000  # split SEVIRI: ASR stream
+    seviri_csr: 30000  # split SEVIRI: CSR stream
 
 # Model parameters
 model:

--- a/gnn_model/FSOI/fsoi_inference.py
+++ b/gnn_model/FSOI/fsoi_inference.py
@@ -146,6 +146,31 @@ def _as_scalar_bin(x):
     return x
 
 
+def _expand_seviri_instrument_aliases(names):
+    """Expand legacy 'seviri' instrument alias to both v7 streams."""
+    if names is None:
+        return None
+    if isinstance(names, str):
+        names = [names]
+
+    expanded = []
+    for name in names:
+        if name == 'seviri':
+            expanded.extend(['seviri_asr', 'seviri_csr'])
+        else:
+            expanded.append(name)
+
+    # Stable de-duplication while preserving order.
+    out = []
+    seen = set()
+    for name in expanded:
+        if name in seen:
+            continue
+        out.append(name)
+        seen.add(name)
+    return out
+
+
 def compute_fsoi_for_pair(
     model,
     prev_batch,
@@ -200,6 +225,11 @@ def compute_fsoi_for_pair(
     target_instruments = fsoi_config['forecast'].get('target_instruments', 'all')
     if target_instruments == 'all':
         target_instruments = None
+    else:
+        expanded_targets = _expand_seviri_instrument_aliases(target_instruments)
+        if expanded_targets != target_instruments:
+            print(f"[FSOI Config] Expanded forecast.target_instruments {target_instruments} -> {expanded_targets}")
+        target_instruments = expanded_targets
 
     # Get target variables filter (e.g., ["temperature"])
     target_variables = fsoi_config['forecast'].get('target_variables', 'all')
@@ -273,10 +303,10 @@ def compute_fsoi_for_pair(
         for inst_name, feats in raw_mask_map.items():
             if feats is None:
                 continue
-            if isinstance(feats, str):
-                feature_mask_map[inst_name] = [feats]
-            else:
-                feature_mask_map[inst_name] = list(feats)
+            expanded_names = _expand_seviri_instrument_aliases(inst_name)
+            feat_list = [feats] if isinstance(feats, str) else list(feats)
+            for expanded_name in expanded_names:
+                feature_mask_map[expanded_name] = list(feat_list)
 
         # ========================================
         # STEP 2: Compute background inputs (xb)
@@ -295,13 +325,23 @@ def compute_fsoi_for_pair(
         # small and do not need capping.
         mem_config = fsoi_config.get('memory', {}) or {}
         max_decoder_nodes_cfg = mem_config.get('max_decoder_nodes', {}) or {}
+        if 'seviri' in max_decoder_nodes_cfg:
+            legacy_cap = max_decoder_nodes_cfg.get('seviri')
+            max_decoder_nodes_cfg = dict(max_decoder_nodes_cfg)
+            max_decoder_nodes_cfg.pop('seviri', None)
+            max_decoder_nodes_cfg.setdefault('seviri_asr', legacy_cap)
+            max_decoder_nodes_cfg.setdefault('seviri_csr', legacy_cap)
+            print(
+                "[FSOI Config] Expanded memory.max_decoder_nodes.seviri "
+                f"-> seviri_asr={max_decoder_nodes_cfg.get('seviri_asr')}, "
+                f"seviri_csr={max_decoder_nodes_cfg.get('seviri_csr')}"
+            )
         # Defaults for known heavy instruments (override in fsoi_config.yaml)
         default_caps = {
             'avhrr': 30000,
             'atms': 50000,
             'amsua': 30000,
             'ssmis': 30000,
-            'seviri': 30000,
             'seviri_asr': 30000,
             'seviri_csr': 30000,
         }
@@ -767,6 +807,12 @@ def main():
         default="cuda:0",
         help="Device to use (default: cuda:0)",
     )
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        default=None,
+        help="Override data directory (default: use train/val global v7 path)",
+    )
 
     args = parser.parse_args()
 
@@ -869,7 +915,15 @@ def main():
     print("\nSetting up data...")
 
     # Determine data path (same logic as train_gnn.py)
-    data_path = "/scratch4/NAGAPE/gpu-ai4wp/Ronald.McLaren/ocelot/data/v6"
+    region = "global"
+    if args.data_path:
+        data_path = args.data_path
+    elif region == "conus":
+        data_path = "/scratch1/NCEPDEV/da/Ronald.McLaren/shared/ocelot/data_v2/"
+    else:
+        data_path = "/scratch4/NAGAPE/gpu-ai4wp/Ronald.McLaren/ocelot/data/v7"
+
+    print(f"Data path: {data_path}")
 
     # Create datamodule for accessing data
     datamodule = GNNDataModule(

--- a/gnn_model/FSOI/fsoi_model_extensions.py
+++ b/gnn_model/FSOI/fsoi_model_extensions.py
@@ -78,21 +78,37 @@ def predict_at_targets(
     # ===========================================================================
     # STEP 1: Copy INPUT nodes from prev_batch (encoder - previous observations)
     # ===========================================================================
+    # NOTE: Skip node types with 0 observations.  PyG's Batch.from_data_list
+    # calls value.max() on edge_index/index attrs and crashes on 0-row tensors,
+    # and a 0-row node store contributes nothing to the forward pass anyway.
     for node_type in prev_batch.node_types:
         if "_input" in node_type:
+            store = prev_batch[node_type]
+            n_rows = 0
+            if hasattr(store, 'x') and store.x is not None:
+                n_rows = store.x.shape[0]
+            elif hasattr(store, 'lat') and store.lat is not None:
+                n_rows = store.lat.shape[0]
+            if n_rows == 0:
+                print(f"[Background] Skipping empty input node store {node_type} (0 obs in prev_batch)")
+                continue
+
             # Copy ALL attributes from prev_batch input nodes
-            for attr_name in prev_batch[node_type].keys():
+            for attr_name in store.keys():
                 if attr_name not in ['edge_index', 'y']:  # Skip edges and targets
-                    forecast_batch[node_type][attr_name] = prev_batch[node_type][attr_name]
+                    forecast_batch[node_type][attr_name] = store[attr_name]
 
             inst_name = node_type.replace("_input", "")
-            print(f"[Background] Copied {node_type} from prev_batch")
+            print(f"[Background] Copied {node_type} from prev_batch ({n_rows} obs)")
 
     # ===========================================================================
     # STEP 2: Build ENCODER edges from prev_batch INPUT locations → mesh
     # ===========================================================================
     for node_type in prev_batch.node_types:
         if "_input" in node_type:
+            # Skip if we did not copy this input node store in STEP 1
+            if node_type not in forecast_batch.node_types:
+                continue
             edge_type = (node_type, "to", "mesh")
 
             # Rebuild encoder edges using prev obs locations
@@ -108,6 +124,10 @@ def predict_at_targets(
                     model.mesh_structure["mesh_list"],
                     o2m=True,  # obs to mesh
                 )
+
+                if edge_index_enc.numel() == 0 or edge_index_enc.shape[1] == 0:
+                    print(f"[Background] Skipping encoder edges for {node_type}: 0 edges")
+                    continue
 
                 forecast_batch[edge_type].edge_index = edge_index_enc
                 forecast_batch[edge_type].edge_attr = edge_attr_enc
@@ -135,6 +155,18 @@ def predict_at_targets(
 
             pseudo_target_type = f"{inst_name}_target_step{forecast_step}"
             curr_input = curr_batch_metadata[node_type_input]
+
+            # Skip instruments with 0 obs in curr_batch — building a 0-row
+            # pseudo-target would later crash Batch.from_data_list.
+            n_curr = 0
+            if hasattr(curr_input, 'x') and curr_input.x is not None:
+                n_curr = curr_input.x.shape[0]
+            elif hasattr(curr_input, 'lat') and curr_input.lat is not None:
+                n_curr = curr_input.lat.shape[0]
+            if n_curr == 0:
+                print(f"[Background] Skipping pseudo-target {pseudo_target_type}: 0 curr obs")
+                subsample_indices[inst_name] = None
+                continue
 
             # ---- optional subsample ----------------------------------------
             N_raw = curr_input.x.shape[0] if hasattr(curr_input, 'x') else 0
@@ -256,6 +288,10 @@ def predict_at_targets(
                     o2m=False,  # mesh to obs (decoder)
                 )
 
+                if edge_index_dec.numel() == 0 or edge_index_dec.shape[1] == 0:
+                    print(f"[Background] Skipping decoder edges to {pseudo_target_type}: 0 edges")
+                    continue
+
                 forecast_batch[edge_type].edge_index = edge_index_dec
                 forecast_batch[edge_type].edge_attr = edge_attr_dec
 
@@ -271,6 +307,29 @@ def predict_at_targets(
         dtype=torch.float32,
         device=device,
     )
+
+    # ---- Defensive scrub: drop any 0-element node/edge stores ------------
+    # PyG's collate calls value.max() on edge_index / index attrs and crashes
+    # if a tensor has numel()==0.  Remove any node/edge type that ended up
+    # empty before batching.
+    for nt in list(forecast_batch.node_types):
+        store = forecast_batch[nt]
+        empty = False
+        for k in list(store.keys()):
+            v = store[k]
+            if torch.is_tensor(v) and v.numel() == 0:
+                empty = True
+                break
+        if empty:
+            print(f"[Background] Scrubbing empty node store {nt} before batching")
+            del forecast_batch[nt]
+
+    for et in list(forecast_batch.edge_types):
+        store = forecast_batch[et]
+        ei = getattr(store, 'edge_index', None)
+        if ei is None or (torch.is_tensor(ei) and ei.numel() == 0):
+            print(f"[Background] Scrubbing empty edge store {et} before batching")
+            del forecast_batch[et]
 
     # Batch and move to device
     forecast_batch = Batch.from_data_list([forecast_batch])

--- a/gnn_model/FSOI/fsoi_utils.py
+++ b/gnn_model/FSOI/fsoi_utils.py
@@ -1511,7 +1511,6 @@ def validate_gradients(
         'cris',
         'airs',
         'ssmis',
-        'seviri',
         'seviri_asr',
         'seviri_csr',
         'avhrr',

--- a/gnn_model/FSOI/plot_all_instruments_by_pressure.py
+++ b/gnn_model/FSOI/plot_all_instruments_by_pressure.py
@@ -33,7 +33,6 @@ INSTRUMENT_NAMES = {
     'amsua': 'AMSU-A',
     'atms': 'ATMS',
     'ssmis': 'SSMIS',
-    'seviri': 'SEVIRI',
     'seviri_asr': 'SEVIRI ASR',
     'seviri_csr': 'SEVIRI CSR',
     'avhrr': 'AVHRR',
@@ -45,7 +44,6 @@ CHANNEL_NAMES = {
     'amsua': {i: f'AMSU-A ch{i+1}' for i in range(15)},
     'atms': {i: f'ATMS ch{i+1}' for i in range(22)},
     'ssmis': {i: f'SSMIS ch{i+1}' for i in range(24)},
-    'seviri': {i: f'SEVIRI ch{i+1}' for i in range(12)},
     'seviri_asr': {i: f'SEVIRI ASR ch{4+i}' for i in range(8)},
     'seviri_csr': {i: f'SEVIRI CSR ch{4+i}' for i in range(8)},
     'avhrr': {i: f'AVHRR ch{i+1}' for i in range(5)},
@@ -281,7 +279,7 @@ def plot_satellite_vs_conventional(df):
     df_pressure = df[df['pressure_hpa'].notna()].copy()
 
     # Categorize observations
-    satellite_types = ['amsua', 'atms', 'ssmis', 'seviri', 'seviri_asr', 'seviri_csr', 'avhrr']
+    satellite_types = ['amsua', 'atms', 'ssmis', 'seviri_asr', 'seviri_csr', 'avhrr']
     conventional_types = ['radiosonde', 'aircraft', 'surface_obs']
 
     df_pressure['obs_category'] = df_pressure['instrument'].apply(
@@ -423,7 +421,7 @@ def main():
     plot_relative_contribution_by_pressure(df)
     plot_top_contributors_by_level(df)
     plot_satellite_vs_conventional(df)
-    plot_satellite_channels_by_pressure(df, instruments=['amsua', 'atms', 'ssmis', 'avhrr', 'ascat', 'seviri_asr', 'seviri_csr', 'seviri'])
+    plot_satellite_channels_by_pressure(df, instruments=['amsua', 'atms', 'ssmis', 'avhrr', 'ascat', 'seviri_asr', 'seviri_csr'])
 
     print("\n" + "="*80)
     print("✓ All plots created successfully!")

--- a/gnn_model/FSOI/scripts/run_fsoi_radiosonde_all.sh
+++ b/gnn_model/FSOI/scripts/run_fsoi_radiosonde_all.sh
@@ -182,6 +182,16 @@ echo "Key settings:"
 echo "  - Target instrument: radiosonde"
 echo "  - Target variables: ALL (T, Td, u, v)"
 echo "  - Forecast lead: +12h (step 0)"
+
+# Data path for FSOI inference (override with env var DATA_PATH if needed)
+DATA_PATH="${DATA_PATH:-/scratch4/NAGAPE/gpu-ai4wp/Ronald.McLaren/ocelot/data/v7}"
+echo "  - Data path: $DATA_PATH"
+
+if [ ! -d "$DATA_PATH" ]; then
+    echo "ERROR: DATA_PATH does not exist: $DATA_PATH"
+    echo "Set a valid path via: DATA_PATH=/path/to/data sbatch $(basename \"$0\") --checkpoint /path/to/model.ckpt"
+    exit 1
+fi
 echo ""
 
 # ========================================================================
@@ -206,7 +216,11 @@ echo ""
 echo "=========================================="
 echo "Step 2: Computing FSOI..."
 echo "=========================================="
-python FSOI/fsoi_inference.py --checkpoint "$CHECKPOINT_PATH" --config "$CONFIG_FILE" 2>&1 | tee "${LOG_DIR}/fsoi_inference_${SLURM_JOB_ID}.log"
+python FSOI/fsoi_inference.py \
+    --checkpoint "$CHECKPOINT_PATH" \
+    --config "$CONFIG_FILE" \
+    --data_path "$DATA_PATH" \
+    2>&1 | tee "${LOG_DIR}/fsoi_inference_${SLURM_JOB_ID}.log"
 
 if [ $? -ne 0 ]; then
     echo "ERROR: FSOI computation failed. Check ${LOG_DIR}/fsoi_inference_${SLURM_JOB_ID}.log"

--- a/gnn_model/FSOI/test_fsoi.py
+++ b/gnn_model/FSOI/test_fsoi.py
@@ -159,7 +159,7 @@ def test_dataset_creation(obs_config, feature_stats):
         test_start = "2024-01-01"
         test_end = "2024-01-03"  # Just 2-3 days
 
-        data_path = "/scratch4/NAGAPE/gpu-ai4wp/Ronald.McLaren/ocelot/data/v6"
+        data_path = "/scratch4/NAGAPE/gpu-ai4wp/Ronald.McLaren/ocelot/data/v7"
 
         print(f"Creating datamodule for {test_start} to {test_end}")
 

--- a/gnn_model/FSOI/visualize_fsoi.py
+++ b/gnn_model/FSOI/visualize_fsoi.py
@@ -621,7 +621,7 @@ def plot_satellite_channel_impacts(df_ch, output_dir):
     print("Creating satellite channel impact plot...")
 
     # Filter for satellite instruments only
-    satellite_instruments = ['atms', 'amsua', 'ssmis', 'seviri', 'seviri_asr', 'seviri_csr', 'avhrr', 'iasi', 'cris', 'airs', 'mhs', 'amsub']
+    satellite_instruments = ['atms', 'amsua', 'ssmis', 'seviri_asr', 'seviri_csr', 'avhrr', 'iasi', 'cris', 'airs', 'mhs', 'amsub']
     df_sat = df_ch[df_ch['instrument'].str.lower().isin(satellite_instruments)].copy()
 
     if df_sat.empty:

--- a/gnn_model/predict_gnn.py
+++ b/gnn_model/predict_gnn.py
@@ -126,7 +126,8 @@ def main():
         if region == "conus":
             data_path = "/scratch1/NCEPDEV/da/Ronald.McLaren/shared/ocelot/data_v2/"
         else:
-            data_path = "/scratch3/NCEPDEV/da/Ronald.McLaren/shared/ocelot/data_v6/global"
+            # Keep prediction defaults aligned with train/val (multi-year merged Zarrs).
+            data_path = "/scratch4/NAGAPE/gpu-ai4wp/Ronald.McLaren/ocelot/data/v7"
     else:
         data_path = args.data_path
 


### PR DESCRIPTION
- Default predict_gnn.py and FSOI to v7 data path
- Split legacy 'seviri' into seviri_asr/seviri_csr (configs + alias expansion)
- run_fsoi_radiosonde_all.sh: explicit DATA_PATH override
- predict_at_targets: skip empty input/target node stores and zero edges; defensive scrub before Batch.from_data_list to avoid PyG max() on empty tensors
- Cleanup of stale 'seviri'/v6 references in plotting/util scripts