### PR TITLE
Recover mesh edge attributes & add target-time conditioning to mesh decode

### DIFF
--- a/gnn_model/evaluation/scripts/compare_mesh_to_gfs_update.py
+++ b/gnn_model/evaluation/scripts/compare_mesh_to_gfs_update.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python
+"""Interpolate GFS forecast and GFS analysis onto OCELOT mesh-grid prediction points.
+
+Author: Azadeh Gholoubi
+
+Mesh-grid prediction CSVs are produced when `enable_mesh_pred: true` and should look like:
+  <mesh_dir>/<instrument>_init_<YYYYMMDDHH>_f<FFF>.csv
+
+This script reads those mesh CSVs and adds:
+  - `gfs_*`  columns: GFS *forecast* interpolated to the same mesh points (existing behaviour)
+  - `anl_*`  columns: GFS *analysis* (f000 of the valid-time cycle) interpolated to the same
+             mesh points, enabling apples-to-apples skill verification of both OCELOT and GFS
+             against a shared ground truth.
+
+Output is a CSV per lead time:
+    <out_dir>/<instrument>_init_<YYYYMMDDHH>_f<FFF>_gfs_on_ocelot_mesh.csv
+
+Notes
+-----
+- anl_* columns are NaN when the valid time does not fall on a 6-hourly GFS cycle
+  (00/06/12/18 Z).  This affects fhr=3, 9, 15, … because no f000 analysis exists
+  for those valid times.
+- Mesh-grid outputs are *predictions only* (no truth).  The analysis therefore
+  serves as the shared ground truth for both OCELOT and GFS forecast verification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Column helpers
+# ---------------------------------------------------------------------------
+
+def _surface_pressure_pred_col(df: pd.DataFrame) -> str | None:
+    for col in (
+        "pred_airPressure_prepbufr_event_1",
+        "pred_airPressure",
+        "pred_pressureMeanSeaLevel_prepbufr",
+    ):
+        if col in df.columns:
+            return col
+    return None
+
+
+def _lon_to_360(lon_deg: np.ndarray) -> np.ndarray:
+    lon = np.asarray(lon_deg, dtype=np.float64)
+    lon = np.mod(lon, 360.0)
+    lon = np.where(lon >= 360.0, lon - 360.0, lon)
+    return lon
+
+
+# ---------------------------------------------------------------------------
+# GFS file paths
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class GfsKey:
+    init_ymdh: str  # YYYYMMDDHH
+    fhr: int
+
+
+def _gfs_path(gfs_root: str, key: GfsKey) -> str:
+    ymd = key.init_ymdh[:8]
+    hh = key.init_ymdh[8:10]
+    return os.path.join(gfs_root, ymd, f"gfs.{ymd}.t{hh}z.pgrb2.0p25.f{key.fhr:03d}")
+
+
+def _valid_time_ymdh(init_ymdh: str, fhr: int) -> str:
+    """Return valid time as YYYYMMDDHH string."""
+    init_dt = datetime.strptime(init_ymdh, "%Y%m%d%H")
+    valid_dt = init_dt + timedelta(hours=fhr)
+    return valid_dt.strftime("%Y%m%d%H")
+
+
+def _analysis_path(gfs_root: str, valid_ymdh: str) -> str:
+    """Return path to the GFS f000 analysis file for the cycle matching valid_ymdh."""
+    ymd = valid_ymdh[:8]
+    hh = valid_ymdh[8:10]
+    return os.path.join(gfs_root, ymd, f"gfs.{ymd}.t{hh}z.pgrb2.0p25.f000")
+
+
+def _is_6h_cycle_hour(valid_ymdh: str) -> bool:
+    """Return True if the valid time falls on a 6-hourly GFS cycle (00/06/12/18Z)."""
+    return int(valid_ymdh[8:10]) in {0, 6, 12, 18}
+
+
+# ---------------------------------------------------------------------------
+# GRIB helpers
+# ---------------------------------------------------------------------------
+
+def _open_cfgrib(path: str, *, type_of_level: str, level: int | None, short_name: str):
+    import cfgrib
+
+    keys = {"typeOfLevel": type_of_level, "shortName": short_name}
+    if level is not None:
+        keys["level"] = int(level)
+    return cfgrib.open_dataset(path, indexpath="", filter_by_keys=keys)
+
+
+def _open_gfs_mean_sea_pressure(path: str):
+    errors: list[str] = []
+    for short_name in ("prmsl", "msl"):
+        try:
+            return _open_cfgrib(path, type_of_level="meanSea", level=None, short_name=short_name)
+        except Exception as exc:
+            errors.append(f"{short_name}: {type(exc).__name__}: {exc}")
+    raise RuntimeError(
+        "Could not open GFS mean sea-level pressure (meanSea/prmsl or meanSea/msl). "
+        + " | ".join(errors)
+    )
+
+
+def _interp_2d(ds, var: str, lat: np.ndarray, lon360: np.ndarray, method: str) -> np.ndarray:
+    import xarray as xr
+
+    lat_da = xr.DataArray(lat.astype(np.float64), dims="points")
+    lon_da = xr.DataArray(lon360.astype(np.float64), dims="points")
+    out = ds[var].interp(latitude=lat_da, longitude=lon_da, method=method)
+    return out.values.astype(np.float64)
+
+
+def _pick_var_name(ds, preferred: str) -> str:
+    if preferred in getattr(ds, "data_vars", {}):
+        return preferred
+    vars_ = list(getattr(ds, "data_vars", {}).keys())
+    if len(vars_) == 1:
+        return vars_[0]
+    raise KeyError(f"Variable {preferred!r} not found; dataset has: {vars_}")
+
+
+def _get_unique_pressure_hpa(df: pd.DataFrame) -> int:
+    if "pressure_hPa" not in df.columns:
+        raise ValueError("mesh CSV for radiosonde/aircraft must include pressure_hPa")
+    p = pd.to_numeric(df["pressure_hPa"], errors="coerce")
+    p = p[np.isfinite(p.to_numpy(dtype=np.float64, na_value=np.nan))]
+    if p.empty:
+        raise ValueError("pressure_hPa is all-NaN; cannot select isobaric GFS level")
+    p0 = float(p.iloc[0])
+    if not np.isfinite(p0):
+        raise ValueError("pressure_hPa first value is not finite")
+    if (np.abs(p.to_numpy(dtype=np.float64) - p0) > 1e-6).any():
+        raise ValueError("mesh CSV contains multiple pressure_hPa values; expected a single fixed level")
+    return int(round(p0))
+
+
+# ---------------------------------------------------------------------------
+# Mesh filename parsing
+# ---------------------------------------------------------------------------
+
+_MESH_FNAME_RE = re.compile(r"^(?P<inst>.+?)_init_(?P<init>\d{10})_f(?P<fhr>\d{3})\.csv$")
+
+
+def _parse_mesh_filename(path: str) -> tuple[str, str, int]:
+    m = _MESH_FNAME_RE.match(os.path.basename(path))
+    if not m:
+        raise ValueError(f"Unexpected mesh CSV filename: {os.path.basename(path)}")
+    return m.group("inst"), m.group("init"), int(m.group("fhr"))
+
+
+# ---------------------------------------------------------------------------
+# Surface mesh: GFS forecast + GFS analysis
+# ---------------------------------------------------------------------------
+
+def add_gfs_to_surface_mesh(mesh_csv: str, gfs_root: str, method: str) -> pd.DataFrame:
+    df = pd.read_csv(mesh_csv)
+    if not {"lat", "lon"}.issubset(df.columns):
+        raise ValueError("mesh CSV must include lat/lon")
+    if "mesh_idx" not in df.columns:
+        raise ValueError(
+            "mesh CSV must include mesh_idx for strict pointwise alignment. "
+            "Re-run prediction with updated code that writes mesh_idx."
+        )
+
+    # Parse/validate mesh_idx early so downstream consumers can merge safely.
+    mesh_idx = pd.to_numeric(df["mesh_idx"], errors="coerce").astype("Int64")
+    if mesh_idx.isna().any():
+        raise ValueError("Found NaN mesh_idx after parsing; cannot align reliably.")
+    if mesh_idx.duplicated().any():
+        raise ValueError("Found duplicate mesh_idx values; cannot align reliably.")
+    df = df.copy()
+    df["mesh_idx"] = mesh_idx.astype(np.int64)
+
+    inst, init, fhr = _parse_mesh_filename(mesh_csv)
+
+    # --- GFS forecast ---
+    gfs_path = _gfs_path(gfs_root, GfsKey(init_ymdh=init, fhr=fhr))
+    if not os.path.exists(gfs_path):
+        raise FileNotFoundError(f"Missing GFS forecast file: {gfs_path}")
+
+    lat = df["lat"].to_numpy(dtype=np.float64)
+    lon360 = _lon_to_360(df["lon"].to_numpy(dtype=np.float64))
+
+    # Open required fields only if the pred_* columns exist.
+    need_u = "pred_wind_u" in df.columns
+    need_v = "pred_wind_v" in df.columns
+    need_t = "pred_airTemperature" in df.columns
+    sp_pred_col = _surface_pressure_pred_col(df)
+    need_sp = sp_pred_col is not None
+
+    gfs_u = gfs_v = gfs_t2m_c = gfs_mslp_hpa = None
+
+    if need_u:
+        ds = _open_cfgrib(gfs_path, type_of_level="heightAboveGround", level=10, short_name="10u")
+        gfs_u = _interp_2d(ds, _pick_var_name(ds, "u10"), lat, lon360, method=method)
+    if need_v:
+        ds = _open_cfgrib(gfs_path, type_of_level="heightAboveGround", level=10, short_name="10v")
+        gfs_v = _interp_2d(ds, _pick_var_name(ds, "v10"), lat, lon360, method=method)
+    if need_t:
+        ds = _open_cfgrib(gfs_path, type_of_level="heightAboveGround", level=2, short_name="2t")
+        gfs_t2m_c = _interp_2d(ds, _pick_var_name(ds, "t2m"), lat, lon360, method=method) - 273.15
+    if need_sp:
+        ds = _open_gfs_mean_sea_pressure(gfs_path)
+        gfs_mslp_hpa = _interp_2d(ds, _pick_var_name(ds, "prmsl"), lat, lon360, method=method) / 100.0
+
+    out = df.copy()
+    if gfs_u is not None:
+        out["gfs_u10"] = gfs_u
+        out["ocelot_minus_gfs_u10"] = out["pred_wind_u"] - out["gfs_u10"]
+    if gfs_v is not None:
+        out["gfs_v10"] = gfs_v
+        out["ocelot_minus_gfs_v10"] = out["pred_wind_v"] - out["gfs_v10"]
+    if gfs_t2m_c is not None:
+        out["gfs_t2m_C"] = gfs_t2m_c
+        out["ocelot_minus_gfs_t2m"] = out["pred_airTemperature"] - out["gfs_t2m_C"]
+    if gfs_mslp_hpa is not None:
+        out["gfs_mslp_hPa"] = gfs_mslp_hpa
+        out["ocelot_minus_gfs_sp"] = out[sp_pred_col] - out["gfs_mslp_hPa"]
+
+    # --- GFS analysis (f000 at valid time) ---
+    # anl_* columns are NaN when the valid time is not on a 6-hourly cycle (no f000 available).
+    valid_ymdh = _valid_time_ymdh(init, fhr)
+    anl_u = anl_v = anl_t2m_c = anl_mslp_hpa = None
+
+    if _is_6h_cycle_hour(valid_ymdh):
+        anl_path = _analysis_path(gfs_root, valid_ymdh)
+        if os.path.exists(anl_path):
+            print(f"[compare_mesh_to_gfs] Loading GFS analysis: {anl_path}")
+            if need_u:
+                ds = _open_cfgrib(anl_path, type_of_level="heightAboveGround", level=10, short_name="10u")
+                anl_u = _interp_2d(ds, _pick_var_name(ds, "u10"), lat, lon360, method=method)
+            if need_v:
+                ds = _open_cfgrib(anl_path, type_of_level="heightAboveGround", level=10, short_name="10v")
+                anl_v = _interp_2d(ds, _pick_var_name(ds, "v10"), lat, lon360, method=method)
+            if need_t:
+                ds = _open_cfgrib(anl_path, type_of_level="heightAboveGround", level=2, short_name="2t")
+                anl_t2m_c = _interp_2d(ds, _pick_var_name(ds, "t2m"), lat, lon360, method=method) - 273.15
+            if need_sp:
+                ds = _open_gfs_mean_sea_pressure(anl_path)
+                anl_mslp_hpa = _interp_2d(ds, _pick_var_name(ds, "prmsl"), lat, lon360, method=method) / 100.0
+        else:
+            print(f"[WARN] GFS analysis file not found: {anl_path}")
+    else:
+        print(f"[compare_mesh_to_gfs] valid time {valid_ymdh} is not on a 6h cycle; anl_* will be NaN")
+
+    # Always write anl_* columns for variables that are present (NaN when analysis unavailable)
+    if need_u:
+        out["anl_u10"] = anl_u if anl_u is not None else np.nan
+        if anl_u is not None:
+            out["ocelot_minus_anl_u10"] = out["pred_wind_u"] - out["anl_u10"]
+            out["gfs_minus_anl_u10"] = out["gfs_u10"] - out["anl_u10"]
+    if need_v:
+        out["anl_v10"] = anl_v if anl_v is not None else np.nan
+        if anl_v is not None:
+            out["ocelot_minus_anl_v10"] = out["pred_wind_v"] - out["anl_v10"]
+            out["gfs_minus_anl_v10"] = out["gfs_v10"] - out["anl_v10"]
+    if need_t:
+        out["anl_t2m_C"] = anl_t2m_c if anl_t2m_c is not None else np.nan
+        if anl_t2m_c is not None:
+            out["ocelot_minus_anl_t2m"] = out["pred_airTemperature"] - out["anl_t2m_C"]
+            out["gfs_minus_anl_t2m"] = out["gfs_t2m_C"] - out["anl_t2m_C"]
+    if need_sp:
+        out["anl_mslp_hPa"] = anl_mslp_hpa if anl_mslp_hpa is not None else np.nan
+        if anl_mslp_hpa is not None:
+            out["ocelot_minus_anl_sp"] = out[sp_pred_col] - out["anl_mslp_hPa"]
+            out["gfs_minus_anl_sp"] = out["gfs_mslp_hPa"] - out["anl_mslp_hPa"]
+
+    out["init_time"] = init
+    out["fhr"] = fhr
+    out["valid_time"] = valid_ymdh
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Isobaric mesh (radiosonde/aircraft): GFS forecast + GFS analysis
+# ---------------------------------------------------------------------------
+
+def add_gfs_to_isobaric_mesh(mesh_csv: str, gfs_root: str, method: str) -> pd.DataFrame:
+    """Add GFS forecast and GFS analysis (isobaric) fields to a radiosonde/aircraft mesh CSV."""
+    df = pd.read_csv(mesh_csv)
+    if not {"lat", "lon"}.issubset(df.columns):
+        raise ValueError("mesh CSV must include lat/lon")
+    if "mesh_idx" not in df.columns:
+        raise ValueError(
+            "mesh CSV must include mesh_idx for strict pointwise alignment. "
+            "Re-run prediction with updated code that writes mesh_idx."
+        )
+
+    # Parse/validate mesh_idx early so downstream consumers can merge safely.
+    mesh_idx = pd.to_numeric(df["mesh_idx"], errors="coerce").astype("Int64")
+    if mesh_idx.isna().any():
+        raise ValueError("Found NaN mesh_idx after parsing; cannot align reliably.")
+    if mesh_idx.duplicated().any():
+        raise ValueError("Found duplicate mesh_idx values; cannot align reliably.")
+    df = df.copy()
+    df["mesh_idx"] = mesh_idx.astype(np.int64)
+
+    inst, init, fhr = _parse_mesh_filename(mesh_csv)
+    level_hpa = _get_unique_pressure_hpa(df)
+
+    lat = df["lat"].to_numpy(dtype=np.float64)
+    lon360 = _lon_to_360(df["lon"].to_numpy(dtype=np.float64))
+
+    # Open required fields only if the pred_* columns exist.
+    need_u = "pred_wind_u" in df.columns
+    need_v = "pred_wind_v" in df.columns
+    need_t = "pred_airTemperature" in df.columns
+
+    # --- GFS forecast ---
+    gfs_path = _gfs_path(gfs_root, GfsKey(init_ymdh=init, fhr=fhr))
+    if not os.path.exists(gfs_path):
+        raise FileNotFoundError(f"Missing GFS forecast file: {gfs_path}")
+
+    gfs_u = gfs_v = gfs_t_c = None
+
+    if need_u:
+        ds = _open_cfgrib(gfs_path, type_of_level="isobaricInhPa", level=level_hpa, short_name="u")
+        gfs_u = _interp_2d(ds, _pick_var_name(ds, "u"), lat, lon360, method=method)
+    if need_v:
+        ds = _open_cfgrib(gfs_path, type_of_level="isobaricInhPa", level=level_hpa, short_name="v")
+        gfs_v = _interp_2d(ds, _pick_var_name(ds, "v"), lat, lon360, method=method)
+    if need_t:
+        ds = _open_cfgrib(gfs_path, type_of_level="isobaricInhPa", level=level_hpa, short_name="t")
+        gfs_t_c = _interp_2d(ds, _pick_var_name(ds, "t"), lat, lon360, method=method) - 273.15
+
+    out = df.copy()
+    out["gfs_level_hPa"] = float(level_hpa)
+    if gfs_u is not None:
+        out["gfs_u"] = gfs_u
+        out["ocelot_minus_gfs_u"] = out["pred_wind_u"] - out["gfs_u"]
+    if gfs_v is not None:
+        out["gfs_v"] = gfs_v
+        out["ocelot_minus_gfs_v"] = out["pred_wind_v"] - out["gfs_v"]
+    if gfs_t_c is not None:
+        out["gfs_airTemperature_C"] = gfs_t_c
+        out["ocelot_minus_gfs_airTemperature"] = out["pred_airTemperature"] - out["gfs_airTemperature_C"]
+
+    # --- GFS analysis (f000 at valid time) ---
+    # anl_* columns are NaN when the valid time is not on a 6-hourly cycle (no f000 available).
+    valid_ymdh = _valid_time_ymdh(init, fhr)
+    anl_u = anl_v = anl_t_c = None
+
+    if _is_6h_cycle_hour(valid_ymdh):
+        anl_path = _analysis_path(gfs_root, valid_ymdh)
+        if os.path.exists(anl_path):
+            print(f"[compare_mesh_to_gfs] Loading GFS analysis: {anl_path}")
+            if need_u:
+                ds = _open_cfgrib(anl_path, type_of_level="isobaricInhPa", level=level_hpa, short_name="u")
+                anl_u = _interp_2d(ds, _pick_var_name(ds, "u"), lat, lon360, method=method)
+            if need_v:
+                ds = _open_cfgrib(anl_path, type_of_level="isobaricInhPa", level=level_hpa, short_name="v")
+                anl_v = _interp_2d(ds, _pick_var_name(ds, "v"), lat, lon360, method=method)
+            if need_t:
+                ds = _open_cfgrib(anl_path, type_of_level="isobaricInhPa", level=level_hpa, short_name="t")
+                anl_t_c = _interp_2d(ds, _pick_var_name(ds, "t"), lat, lon360, method=method) - 273.15
+        else:
+            print(f"[WARN] GFS analysis file not found: {anl_path}")
+    else:
+        print(f"[compare_mesh_to_gfs] valid time {valid_ymdh} is not on a 6h cycle; anl_* will be NaN")
+
+    if need_u:
+        out["anl_u"] = anl_u if anl_u is not None else np.nan
+        if anl_u is not None:
+            out["ocelot_minus_anl_u"] = out["pred_wind_u"] - out["anl_u"]
+            out["gfs_minus_anl_u"] = out["gfs_u"] - out["anl_u"]
+    if need_v:
+        out["anl_v"] = anl_v if anl_v is not None else np.nan
+        if anl_v is not None:
+            out["ocelot_minus_anl_v"] = out["pred_wind_v"] - out["anl_v"]
+            out["gfs_minus_anl_v"] = out["gfs_v"] - out["anl_v"]
+    if need_t:
+        out["anl_airTemperature_C"] = anl_t_c if anl_t_c is not None else np.nan
+        if anl_t_c is not None:
+            out["ocelot_minus_anl_airTemperature"] = out["pred_airTemperature"] - out["anl_airTemperature_C"]
+            out["gfs_minus_anl_airTemperature"] = out["gfs_airTemperature_C"] - out["anl_airTemperature_C"]
+
+    out["init_time"] = init
+    out["fhr"] = fhr
+    out["valid_time"] = valid_ymdh
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Interpolate GFS forecast and analysis onto OCELOT mesh-grid prediction points."
+    )
+    ap.add_argument(
+        "--mesh_csv",
+        required=True,
+        help="Mesh-grid prediction CSV, e.g. surface_obs_init_YYYYMMDDHH_f003.csv",
+    )
+    ap.add_argument(
+        "--gfs_root",
+        default="/scratch3/NCEPDEV/da/Mu-Chieh.Ko/JEDI-nudging/gfs-rt25",
+    )
+    ap.add_argument("--out_csv", required=True)
+    ap.add_argument("--interp", default="nearest", choices=["nearest", "linear"])
+    args = ap.parse_args()
+
+    inst, _init, _fhr = _parse_mesh_filename(args.mesh_csv)
+    if inst in {"surface_obs", "surface"}:
+        out = add_gfs_to_surface_mesh(args.mesh_csv, gfs_root=args.gfs_root, method=args.interp)
+    elif inst == "radiosonde":
+        out = add_gfs_to_isobaric_mesh(args.mesh_csv, gfs_root=args.gfs_root, method=args.interp)
+    else:
+        raise SystemExit(
+            f"Unsupported mesh instrument={inst!r} in {os.path.basename(args.mesh_csv)}. "
+            "Supported: surface_obs, radiosonde."
+        )
+
+    os.makedirs(os.path.dirname(args.out_csv) or ".", exist_ok=True)
+    out.to_csv(args.out_csv, index=False)
+    print(f"Wrote: {args.out_csv} (rows={len(out)})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gnn_model/evaluation/scripts/plot_mesh_vs_gfs_maps_update.py
+++ b/gnn_model/evaluation/scripts/plot_mesh_vs_gfs_maps_update.py
@@ -178,9 +178,9 @@ _INIT_FHR_RE = re.compile(r"init_(?P<init>\d{10}).*?_f(?P<fhr>\d{3})")
 def _infer_init_fhr(df: pd.DataFrame, csv_path: str) -> tuple[str, int]:
     if "init_time" in df.columns and "fhr" in df.columns:
         init = str(df["init_time"].iloc[0])
-        fhr = int(pd.to_numeric(df["fhr"].iloc[0], errors="coerce"))
-        if init.isdigit() and len(init) == 10 and np.isfinite(float(fhr)):
-            return init, fhr
+        fhr_value = pd.to_numeric(df["fhr"].iloc[0], errors="coerce")
+        if init.isdigit() and len(init) == 10 and np.isfinite(fhr_value):
+            return init, int(fhr_value)
     m = _INIT_FHR_RE.search(os.path.basename(str(csv_path)))
     if m:
         return m.group("init"), int(m.group("fhr"))
@@ -560,7 +560,7 @@ def main() -> int:
         f" • init={df['init_time'].iloc[0] if 'init_time' in df.columns else ''}"
         f" fhr={df['fhr'].iloc[0] if 'fhr' in df.columns else ''}"
     )
-    level_suffix = f"_{'_' + level_tag if level_tag else ''}"
+    level_suffix = f"_{level_tag if level_tag else ''}"
 
     instrument = os.path.basename(args.csv).split("_init_")[0]
 

--- a/gnn_model/evaluation/scripts/plot_mesh_vs_gfs_maps_update.py
+++ b/gnn_model/evaluation/scripts/plot_mesh_vs_gfs_maps_update.py
@@ -560,7 +560,7 @@ def main() -> int:
         f" • init={df['init_time'].iloc[0] if 'init_time' in df.columns else ''}"
         f" fhr={df['fhr'].iloc[0] if 'fhr' in df.columns else ''}"
     )
-    level_suffix = f"_{level_tag if level_tag else ''}"
+    level_suffix = f"{'_' + level_tag if level_tag else ''}"
 
     instrument = os.path.basename(args.csv).split("_init_")[0]
 

--- a/gnn_model/evaluation/scripts/plot_mesh_vs_gfs_maps_update.py
+++ b/gnn_model/evaluation/scripts/plot_mesh_vs_gfs_maps_update.py
@@ -1,0 +1,618 @@
+#!/usr/bin/env python
+"""Plot OCELOT mesh-grid predictions vs GFS forecast (and optionally GFS analysis).
+
+Author: Azadeh Gholoubi
+
+Reads a CSV produced by compare_mesh_to_gfs.py and generates:
+
+  - 3-panel plot  (odd fhrs: no analysis available)
+      OCELOT forecast | GFS forecast | OCELOT − GFS
+
+  - 6-panel plot  (even 6h fhrs: GFS analysis present)
+      Row 1:  OCELOT forecast | GFS forecast    | GFS analysis
+      Row 2:  OCELOT − GFS   | OCELOT − analysis | GFS − analysis
+
+The script auto-detects which layout to use based on whether the anl_* column
+for the requested variable contains any non-NaN values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+
+import numpy as np
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Cartopy / plotting helpers
+# ---------------------------------------------------------------------------
+
+def _require_plotting() -> None:
+    try:
+        import cartopy  # noqa: F401
+        import matplotlib  # noqa: F401
+    except ImportError as e:
+        raise SystemExit(f"Plotting requires cartopy and matplotlib: {e}")
+
+
+def _ensure_dir(path: str) -> None:
+    if path:
+        os.makedirs(path, exist_ok=True)
+
+
+_CARTOPY_FEATURES_WARNED = False
+
+
+def _add_land(ax) -> None:
+    global _CARTOPY_FEATURES_WARNED
+    import cartopy.feature as cfeature
+
+    mode = os.environ.get("OCELOT_CARTOPY_FEATURES", "auto").strip().lower()
+    if mode in {"0", "false", "no", "off"}:
+        return
+    try:
+        ax.add_feature(cfeature.COASTLINE, linewidth=0.5)
+        ax.add_feature(cfeature.BORDERS, linewidth=0.3)
+        ax.add_feature(cfeature.LAND, facecolor="lightgray", alpha=0.3)
+    except Exception as e:
+        if not _CARTOPY_FEATURES_WARNED:
+            _CARTOPY_FEATURES_WARNED = True
+            print(
+                f"[WARN] Could not add Cartopy land features (offline node?). "
+                f"(Set OCELOT_CARTOPY_FEATURES=1 to force.) Error={type(e).__name__}: {e}"
+            )
+        try:
+            ax.stock_img()
+        except Exception:
+            pass
+
+
+def _to_lon180(lon_deg: np.ndarray) -> np.ndarray:
+    lon = np.asarray(lon_deg, dtype=np.float64)
+    return (np.mod(lon + 180.0, 360.0) - 180.0).astype(np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Statistics / colour-limit helpers
+# ---------------------------------------------------------------------------
+
+def _metrics(a: np.ndarray, b: np.ndarray) -> dict:
+    aa = np.asarray(a, dtype=np.float64)
+    bb = np.asarray(b, dtype=np.float64)
+    m = np.isfinite(aa) & np.isfinite(bb)
+    n = int(np.count_nonzero(m))
+    if n == 0:
+        return {"n": 0, "rmse": float("nan"), "bias": float("nan"), "corr": float("nan")}
+    d = aa[m] - bb[m]
+    bias = float(np.mean(d))
+    rmse = float(np.sqrt(np.mean(d * d)))
+    corr = float("nan")
+    if n >= 2:
+        try:
+            corr = float(np.corrcoef(aa[m], bb[m])[0, 1])
+        except Exception:
+            corr = float("nan")
+    return {"n": n, "rmse": rmse, "bias": bias, "corr": corr}
+
+
+def _robust_limits(data: np.ndarray, q_lo: float, q_hi: float) -> tuple[float, float]:
+    d = data[np.isfinite(data)]
+    if len(d) == 0:
+        return -1.0, 1.0
+    return float(np.percentile(d, q_lo)), float(np.percentile(d, q_hi))
+
+
+def _robust_sym(data: np.ndarray, q_hi: float) -> tuple[float, float]:
+    d = data[np.isfinite(data)]
+    if len(d) == 0:
+        return -1.0, 1.0
+    v = float(np.percentile(np.abs(d), q_hi))
+    return -v, v
+
+
+# ---------------------------------------------------------------------------
+# GFS file path (used for native-vs-interpolated diagnostic)
+# ---------------------------------------------------------------------------
+
+def _gfs_path(gfs_root: str, init_ymdh: str, fhr: int) -> str:
+    ymd = str(init_ymdh)[:8]
+    hh = str(init_ymdh)[8:10]
+    return os.path.join(str(gfs_root), ymd, f"gfs.{ymd}.t{hh}z.pgrb2.0p25.f{int(fhr):03d}")
+
+
+def _open_gfs_mean_sea_pressure(path: str):
+    import cfgrib
+
+    for short_name in ("prmsl", "msl"):
+        try:
+            return cfgrib.open_dataset(
+                path, indexpath="",
+                filter_by_keys={"typeOfLevel": "meanSea", "shortName": short_name},
+            )
+        except Exception:
+            pass
+    raise RuntimeError(f"Could not open GFS mean sea-level pressure from {path}")
+
+
+def _open_gfs(path: str, var: str, *, level_hpa: int | None = None):
+    import cfgrib
+
+    if var == "u10":
+        return cfgrib.open_dataset(
+            path, indexpath="",
+            filter_by_keys={"typeOfLevel": "heightAboveGround", "level": 10, "shortName": "10u"},
+        )
+    if var == "v10":
+        return cfgrib.open_dataset(
+            path, indexpath="",
+            filter_by_keys={"typeOfLevel": "heightAboveGround", "level": 10, "shortName": "10v"},
+        )
+    if var == "t2m":
+        return cfgrib.open_dataset(
+            path, indexpath="",
+            filter_by_keys={"typeOfLevel": "heightAboveGround", "level": 2, "shortName": "2t"},
+        )
+    if var == "sp":
+        return _open_gfs_mean_sea_pressure(path)
+    if var in {"u", "v", "temp"}:
+        if level_hpa is None:
+            raise ValueError("isobaric plotting requires level_hpa")
+        short = {"u": "u", "v": "v", "temp": "t"}[var]
+        return cfgrib.open_dataset(
+            path, indexpath="",
+            filter_by_keys={"typeOfLevel": "isobaricInhPa", "level": int(level_hpa), "shortName": short},
+        )
+    raise ValueError(f"Unsupported var={var!r}")
+
+
+# ---------------------------------------------------------------------------
+# init/fhr inference from CSV
+# ---------------------------------------------------------------------------
+
+_INIT_FHR_RE = re.compile(r"init_(?P<init>\d{10}).*?_f(?P<fhr>\d{3})")
+
+
+def _infer_init_fhr(df: pd.DataFrame, csv_path: str) -> tuple[str, int]:
+    if "init_time" in df.columns and "fhr" in df.columns:
+        init = str(df["init_time"].iloc[0])
+        fhr = int(pd.to_numeric(df["fhr"].iloc[0], errors="coerce"))
+        if init.isdigit() and len(init) == 10 and np.isfinite(float(fhr)):
+            return init, fhr
+    m = _INIT_FHR_RE.search(os.path.basename(str(csv_path)))
+    if m:
+        return m.group("init"), int(m.group("fhr"))
+    raise ValueError(
+        "Could not infer init_time/fhr from CSV "
+        "(need init_time+fhr columns or init_YYYYMMDDHH_fFFF in filename)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Surface-pressure column helper
+# ---------------------------------------------------------------------------
+
+def _surface_pressure_pred_col(df: pd.DataFrame) -> str | None:
+    for col in (
+        "pred_airPressure_prepbufr_event_1",
+        "pred_airPressure",
+        "pred_pressureMeanSeaLevel_prepbufr",
+    ):
+        if col in df.columns:
+            return col
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 3-panel plot  (no analysis)
+# ---------------------------------------------------------------------------
+
+def plot_tripanel(
+    lon: np.ndarray,
+    lat: np.ndarray,
+    pred: np.ndarray,
+    gfs: np.ndarray,
+    title: str,
+    out_png: str,
+    units: str | None,
+    point_size: int,
+) -> None:
+    import cartopy.crs as ccrs
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import TwoSlopeNorm
+
+    diff = pred - gfs
+    m = _metrics(pred, gfs)
+    stats_line = f"N={m['n']}  RMSE={m['rmse']:.3g}  Bias={m['bias']:.3g}  Corr={m['corr']:.3f}"
+    vmin, vmax = _robust_limits(np.concatenate([pred, gfs]), 1.0, 99.0)
+    dmin, dmax = _robust_sym(diff, 99.0)
+
+    fig, axes = plt.subplots(
+        1, 3,
+        figsize=(20, 5),
+        subplot_kw={"projection": ccrs.PlateCarree()},
+        sharey=True,
+    )
+    panels = [
+        ("OCELOT", pred, "turbo", None),
+        ("GFS", gfs, "turbo", None),
+        ("OCELOT − GFS", diff, "bwr", TwoSlopeNorm(vmin=dmin, vcenter=0.0, vmax=dmax)),
+    ]
+
+    for ax, (ttl, field, cmap, norm) in zip(axes, panels):
+        ax.set_title(ttl, fontsize=14)
+        if norm is None:
+            sc = ax.scatter(lon, lat, c=field, s=point_size, cmap=cmap,
+                            vmin=vmin, vmax=vmax, transform=ccrs.PlateCarree())
+            cb = fig.colorbar(sc, ax=ax, orientation="vertical", pad=0.02)
+            cb.set_label(f"Value{f' ({units})' if units else ''}")
+        else:
+            sc = ax.scatter(lon, lat, c=field, s=point_size, cmap=cmap,
+                            norm=norm, transform=ccrs.PlateCarree())
+            cb = fig.colorbar(sc, ax=ax, orientation="vertical", pad=0.02)
+            cb.set_label(f"Δ{f' ({units})' if units else ''}")
+        _add_land(ax)
+        ax.set_global()
+
+    fig.suptitle(f"{title}\n{stats_line}", fontsize=14, y=1.05)
+    plt.tight_layout()
+    plt.savefig(out_png, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"Wrote: {out_png}")
+
+
+# ---------------------------------------------------------------------------
+# 6-panel plot  (with analysis)
+# ---------------------------------------------------------------------------
+
+def plot_sixpanel(
+    lon: np.ndarray,
+    lat: np.ndarray,
+    pred: np.ndarray,
+    gfs: np.ndarray,
+    anl: np.ndarray,
+    title: str,
+    out_png: str,
+    units: str | None,
+    point_size: int,
+) -> None:
+    """2-row × 3-col layout:
+      Row 1: OCELOT forecast  | GFS forecast    | GFS analysis
+      Row 2: OCELOT − GFS     | OCELOT − analysis | GFS − analysis
+    """
+    import cartopy.crs as ccrs
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import TwoSlopeNorm
+
+    diff_og = pred - gfs          # OCELOT − GFS forecast
+    diff_oa = pred - anl          # OCELOT − analysis
+    diff_ga = gfs - anl           # GFS forecast − analysis
+
+    m_og = _metrics(pred, gfs)
+    m_oa = _metrics(pred, anl)
+    m_ga = _metrics(gfs, anl)
+
+    # Shared absolute colour limits across all three value panels
+    vmin, vmax = _robust_limits(np.concatenate([pred, gfs, anl]), 1.0, 99.0)
+
+    # Shared difference colour limits across all three diff panels
+    all_diffs = np.concatenate([
+        diff_og[np.isfinite(diff_og)],
+        diff_oa[np.isfinite(diff_oa)],
+        diff_ga[np.isfinite(diff_ga)],
+    ])
+    dmin, dmax = _robust_sym(all_diffs, 99.0)
+    diff_norm = TwoSlopeNorm(vmin=dmin, vcenter=0.0, vmax=dmax)
+
+    fig, axes = plt.subplots(
+        2, 3,
+        figsize=(20, 10),
+        subplot_kw={"projection": ccrs.PlateCarree()},
+        sharex=True,
+        sharey=True,
+    )
+
+    val_label = f"Value{f' ({units})' if units else ''}"
+    diff_label = f"Δ{f' ({units})' if units else ''}"
+
+    # Row 0: absolute fields
+    row0 = [
+        ("OCELOT forecast", pred),
+        ("GFS forecast", gfs),
+        ("GFS analysis (truth)", anl),
+    ]
+    for ax, (ttl, field) in zip(axes[0], row0):
+        ax.set_title(ttl, fontsize=13)
+        sc = ax.scatter(lon, lat, c=field, s=point_size, cmap="turbo",
+                        vmin=vmin, vmax=vmax, transform=ccrs.PlateCarree())
+        fig.colorbar(sc, ax=ax, orientation="vertical", pad=0.02).set_label(val_label)
+        _add_land(ax)
+        ax.set_global()
+
+    # Row 1: difference fields
+    row1 = [
+        (f"OCELOT − GFS  (RMSE={m_og['rmse']:.3g}  Bias={m_og['bias']:.3g})", diff_og),
+        (f"OCELOT − analysis  (RMSE={m_oa['rmse']:.3g}  Bias={m_oa['bias']:.3g})", diff_oa),
+        (f"GFS − analysis  (RMSE={m_ga['rmse']:.3g}  Bias={m_ga['bias']:.3g})", diff_ga),
+    ]
+    for ax, (ttl, field) in zip(axes[1], row1):
+        ax.set_title(ttl, fontsize=11)
+        sc = ax.scatter(lon, lat, c=field, s=point_size, cmap="bwr",
+                        norm=diff_norm, transform=ccrs.PlateCarree())
+        fig.colorbar(sc, ax=ax, orientation="vertical", pad=0.02).set_label(diff_label)
+        _add_land(ax)
+        ax.set_global()
+
+    fig.suptitle(f"{title}  |  N={m_og['n']}", fontsize=14, y=1.01)
+    plt.tight_layout()
+    plt.savefig(out_png, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"Wrote: {out_png}")
+
+
+# ---------------------------------------------------------------------------
+# Native GFS grid vs interpolated diagnostic
+# ---------------------------------------------------------------------------
+
+def plot_gfs_native_vs_mesh_interp(
+    *,
+    lon: np.ndarray,
+    lat: np.ndarray,
+    gfs_on_mesh: np.ndarray,
+    var: str,
+    units: str | None,
+    init_ymdh: str,
+    fhr: int,
+    gfs_root: str,
+    interp_method: str,
+    out_png: str,
+    point_size: int,
+    grid_stride: int,
+    level_hpa: int | None = None,
+) -> None:
+    import cartopy.crs as ccrs
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    gfs_p = _gfs_path(gfs_root, init_ymdh=init_ymdh, fhr=int(fhr))
+    if not os.path.exists(gfs_p):
+        raise FileNotFoundError(f"Missing GFS file: {gfs_p}")
+
+    ds = _open_gfs(gfs_p, var=var, level_hpa=level_hpa)
+    ds_var = {"u10": "u10", "v10": "v10", "t2m": "t2m", "sp": "prmsl",
+              "u": "u", "v": "v", "temp": "t"}[var]
+    if ds_var not in ds:
+        keys = list(getattr(ds, "data_vars", {}).keys())
+        if len(keys) != 1:
+            raise KeyError(f"Variable {ds_var!r} not in GRIB; available: {keys}")
+        ds_var = keys[0]
+
+    field = np.asarray(ds[ds_var].values, dtype=np.float64)
+    glat = np.asarray(ds["latitude"].values, dtype=np.float64)
+    glon = np.asarray(ds["longitude"].values, dtype=np.float64)
+
+    if var in {"t2m", "temp"}:
+        field = field - 273.15
+    elif var == "sp":
+        field = field / 100.0
+
+    stride = max(1, int(grid_stride))
+    field = field[::stride, ::stride]
+    glat = glat[::stride]
+    glon = glon[::stride]
+
+    glon180 = _to_lon180(glon)
+    order = np.argsort(glon180)
+    glon180 = glon180[order]
+    field = field[:, order]
+
+    pooled = np.concatenate([
+        field[np.isfinite(field)],
+        np.asarray(gfs_on_mesh, dtype=np.float64)[np.isfinite(gfs_on_mesh)],
+    ])
+    if var in {"u10", "v10"}:
+        vmin, vmax = _robust_sym(pooled, 99.0)
+        cmap = "coolwarm"
+    else:
+        vmin, vmax = _robust_limits(pooled, 1.0, 99.0)
+        cmap = "turbo"
+
+    fig, axes = plt.subplots(
+        1, 2,
+        figsize=(18, 5.5),
+        subplot_kw={"projection": ccrs.PlateCarree()},
+        sharey=True,
+    )
+
+    ax0 = axes[0]
+    ax0.set_title(f"GFS native GRIB ({var})\ninit={init_ymdh} f{int(fhr):03d}")
+    m0 = ax0.pcolormesh(glon180, glat, field, shading="auto", cmap=cmap,
+                        vmin=vmin, vmax=vmax, transform=ccrs.PlateCarree())
+    _add_land(ax0)
+    ax0.set_global()
+    fig.colorbar(m0, ax=ax0, orientation="vertical", pad=0.02, fraction=0.05).set_label(
+        f"{var}{f' ({units})' if units else ''}"
+    )
+
+    ax1 = axes[1]
+    ax1.set_title(f"GFS interpolated onto OCELOT mesh ({interp_method})")
+    sc = ax1.scatter(lon, lat, c=gfs_on_mesh, s=point_size, cmap=cmap,
+                     vmin=vmin, vmax=vmax, transform=ccrs.PlateCarree())
+    _add_land(ax1)
+    ax1.set_global()
+    fig.colorbar(sc, ax=ax1, orientation="vertical", pad=0.02, fraction=0.05).set_label(
+        f"{var}{f' ({units})' if units else ''}"
+    )
+
+    fig.suptitle("GFS native vs interpolated-to-mesh diagnostic", fontsize=14, y=1.02)
+    plt.tight_layout()
+    plt.savefig(out_png, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"Wrote: {out_png}")
+
+
+# ---------------------------------------------------------------------------
+# Column mapping: var name → (pred_col, gfs_col, anl_col, units)
+# ---------------------------------------------------------------------------
+
+def _col_map(var: str, df: pd.DataFrame) -> tuple[str | None, str, str, str | None]:
+    """Return (pred_col, gfs_col, anl_col, units) for the requested variable."""
+    if var == "u10":
+        return "pred_wind_u", "gfs_u10", "anl_u10", "m/s"
+    if var == "v10":
+        return "pred_wind_v", "gfs_v10", "anl_v10", "m/s"
+    if var == "t2m":
+        return "pred_airTemperature", "gfs_t2m_C", "anl_t2m_C", "°C"
+    if var == "sp":
+        pred_col = _surface_pressure_pred_col(df)
+        return pred_col, "gfs_mslp_hPa", "anl_mslp_hPa", "hPa"
+    if var == "u":
+        return "pred_wind_u", "gfs_u", "anl_u", "m/s"
+    if var == "v":
+        return "pred_wind_v", "gfs_v", "anl_v", "m/s"
+    # temp
+    return "pred_airTemperature", "gfs_airTemperature_C", "anl_airTemperature_C", "°C"
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Plot OCELOT mesh-grid predictions vs GFS forecast "
+            "(and GFS analysis when available)."
+        )
+    )
+    ap.add_argument(
+        "--csv",
+        required=True,
+        help=(
+            "CSV produced by compare_mesh_to_gfs.py containing pred_*, gfs_*, and "
+            "optionally anl_* columns.  Common names: *_gfs_on_ocelot_mesh.csv"
+        ),
+    )
+    ap.add_argument("--plot_dir", required=True)
+    ap.add_argument("--var", required=True, choices=["u10", "v10", "t2m", "sp", "u", "v", "temp"])
+    ap.add_argument("--point_size", type=int, default=5)
+    ap.add_argument(
+        "--gfs_root",
+        default=None,
+        help="If provided, also plot native GFS GRIB vs interpolated-to-mesh for diagnostics.",
+    )
+    ap.add_argument("--interp", default="nearest", choices=["nearest", "linear"])
+    ap.add_argument("--grid_stride", type=int, default=2)
+    args = ap.parse_args()
+
+    _require_plotting()
+    _ensure_dir(args.plot_dir)
+
+    df = pd.read_csv(args.csv)
+    lon = pd.to_numeric(df["lon"], errors="coerce").to_numpy(dtype=np.float64)
+    lat = pd.to_numeric(df["lat"], errors="coerce").to_numpy(dtype=np.float64)
+
+    pred_col, gfs_col, anl_col, units = _col_map(args.var, df)
+
+    # Level tag for isobaric variables
+    level_tag = ""
+    level_hpa = None
+    if "pressure_level_label" in df.columns and df["pressure_level_label"].notna().any():
+        level_tag = str(df["pressure_level_label"].dropna().iloc[0])
+    elif "pressure_hPa" in df.columns and pd.to_numeric(df["pressure_hPa"], errors="coerce").notna().any():
+        level_hpa = int(round(float(pd.to_numeric(df["pressure_hPa"], errors="coerce").dropna().iloc[0])))
+        level_tag = f"{level_hpa}hPa"
+    if level_hpa is None and level_tag.endswith("hPa"):
+        try:
+            level_hpa = int(level_tag.replace("hPa", ""))
+        except Exception:
+            level_hpa = None
+
+    if pred_col is None or pred_col not in df.columns or gfs_col not in df.columns:
+        raise SystemExit(f"Missing columns for {args.var}: need {pred_col!r} and {gfs_col!r}")
+
+    pred = pd.to_numeric(df[pred_col], errors="coerce").to_numpy(dtype=np.float64)
+    gfs = pd.to_numeric(df[gfs_col], errors="coerce").to_numpy(dtype=np.float64)
+
+    # Check whether analysis data is present and non-NaN for this CSV
+    has_analysis = (
+        anl_col in df.columns
+        and pd.to_numeric(df[anl_col], errors="coerce").notna().any()
+    )
+    if has_analysis:
+        anl = pd.to_numeric(df[anl_col], errors="coerce").to_numpy(dtype=np.float64)
+    else:
+        anl = None
+
+    lvl = f" • {level_tag}" if level_tag else ""
+    base_title = (
+        f"mesh-grid {args.var}{lvl}"
+        f" • init={df['init_time'].iloc[0] if 'init_time' in df.columns else ''}"
+        f" fhr={df['fhr'].iloc[0] if 'fhr' in df.columns else ''}"
+    )
+    level_suffix = f"_{'_' + level_tag if level_tag else ''}"
+
+    instrument = os.path.basename(args.csv).split("_init_")[0]
+
+    if has_analysis:
+        # 6-panel: need all three to be finite at the same points
+        valid = np.isfinite(lon) & np.isfinite(lat) & np.isfinite(pred) & np.isfinite(gfs) & np.isfinite(anl)
+        _lon, _lat, _pred, _gfs, _anl = lon[valid], lat[valid], pred[valid], gfs[valid], anl[valid]
+
+        title = f"{base_title} • vs GFS forecast + analysis"
+        out_png = os.path.join(
+            args.plot_dir,
+            f"{instrument}_mesh_6panel_{args.var}{level_suffix}.png",
+        )
+        plot_sixpanel(_lon, _lat, _pred, _gfs, _anl, title, out_png,
+                      units=units, point_size=int(args.point_size))
+    else:
+        # 3-panel: original behaviour
+        valid = np.isfinite(lon) & np.isfinite(lat) & np.isfinite(pred) & np.isfinite(gfs)
+        _lon, _lat, _pred, _gfs = lon[valid], lat[valid], pred[valid], gfs[valid]
+
+        title = f"{base_title} • OCELOT_on_mesh vs GFS_on_mesh"
+        out_png = os.path.join(
+            args.plot_dir,
+            f"{instrument}_mesh_OCELOT_vs_GFS_{args.var}{level_suffix}.png",
+        )
+        plot_tripanel(_lon, _lat, _pred, _gfs, title, out_png,
+                      units=units, point_size=int(args.point_size))
+
+    # Optional native-GFS diagnostic (unchanged from original)
+    if args.gfs_root:
+        init_ymdh, fhr = _infer_init_fhr(df, csv_path=str(args.csv))
+        out_png2 = os.path.join(
+            args.plot_dir,
+            f"mesh_GFS_native_vs_GFS_on_mesh_{args.var}{level_suffix}_init_{init_ymdh}_f{int(fhr):03d}.png",
+        )
+        plot_gfs_native_vs_mesh_interp(
+            lon=_lon,
+            lat=_lat,
+            gfs_on_mesh=_gfs,
+            var=str(args.var),
+            units=units,
+            init_ymdh=str(init_ymdh),
+            fhr=int(fhr),
+            gfs_root=str(args.gfs_root),
+            interp_method=str(args.interp),
+            out_png=str(out_png2),
+            point_size=int(args.point_size),
+            grid_stride=int(args.grid_stride),
+            level_hpa=level_hpa,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gnn_model/evaluation/scripts/run_evaluation_gnn_env.sh
+++ b/gnn_model/evaluation/scripts/run_evaluation_gnn_env.sh
@@ -14,9 +14,9 @@
 
 
 #Script to run evaluations for multiple initialization times
-#Submit with: sbatch evaluation/scripts/run_evaluation.sh [START_DATE] [END_DATE]
-#Example: sbatch evaluation/scripts/run_evaluation.sh 2023010100 2023010912
-#Or use defaults: sbatch evaluation/scripts/run_evaluation.sh
+#Submit with: sbatch evaluation/scripts/run_evaluation_gnn_env.sh [START_DATE] [END_DATE]
+#Example: sbatch evaluation/scripts/run_evaluation_gnn_env.sh 2023010100 2023010912
+#Or use defaults: sbatch evaluation/scripts/run_evaluation_gnn_env.sh
 
 #set -e  # Exit on error
 

--- a/gnn_model/evaluation/scripts/run_evaluation_gnn_env.sh
+++ b/gnn_model/evaluation/scripts/run_evaluation_gnn_env.sh
@@ -1,0 +1,243 @@
+#!/bin/bash -l
+#SBATCH --exclude=u22g09,u22g08,u22g10,u23g12
+#SBATCH -A da-cpu
+#SBATCH -p u1-service
+#SBATCH -J gnn_eval
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=32G
+#SBATCH -t 08:00:00
+#SBATCH --output=gnn_eval_%j.out
+#SBATCH --error=gnn_eval_%j.err
+#SBATCH --mail-type=BEGIN,END,FAIL
+
+
+#Script to run evaluations for multiple initialization times
+#Submit with: sbatch evaluation/scripts/run_evaluation.sh [START_DATE] [END_DATE]
+#Example: sbatch evaluation/scripts/run_evaluation.sh 2023010100 2023010912
+#Or use defaults: sbatch evaluation/scripts/run_evaluation.sh
+
+#set -e  # Exit on error
+
+echo "================================================"
+echo "Starting batch evaluation on $(hostname)"
+echo "Node: $(hostname)"
+echo "Architecture: $(uname -m)"
+echo "================================================"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GNN_MODEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+OCELOT_DIR="$(cd "${GNN_MODEL_DIR}/.." && pwd)"
+
+cd "${SLURM_SUBMIT_DIR:-${GNN_MODEL_DIR}}"
+
+# Load Conda environment
+source /scratch3/NCEPDEV/da/Azadeh.Gholoubi/miniconda3/etc/profile.d/conda.sh
+conda activate gnn-env
+
+# Add PYTHONPATH
+export PYTHONPATH="${GNN_MODEL_DIR}:${OCELOT_DIR}:${PYTHONPATH:-}"
+
+# ============================================
+# CONFIGURATION - Set all parameters here
+# ============================================
+
+# MODE:
+#   standard    -> runs evaluations.py (pred vs truth)
+#   gfs_compare -> runs plot_gfs_compare.py (pred/truth vs GFS from *_vs_gfs.csv)
+MODE=${MODE:-"standard"}
+
+# For MODE=gfs_compare
+# Valid: surface_obs | radiosonde | aircraft
+INSTRUMENT=${INSTRUMENT:-"surface_obs"}
+CHUNKSIZE=${CHUNKSIZE:-"200000"}
+VARS=${VARS:-"wind"}
+
+EVAL_SCRIPT="evaluation/scripts/evaluations.py"
+GFS_COMPARE_SCRIPT="evaluation/scripts/plot_gfs_compare.py"
+
+# --- Training Mode Parameters ---
+# Leave empty ("") for testing mode, or set for training mode:
+EPOCH_TO_PLOT=""
+BATCH_IDX_TO_PLOT=""
+
+# --- Data Directories ---
+# Training mode example:
+#   DATA_DIR="val_csv"                             # Training validation (obs location; set HAS_GROUND_TRUTH = true)
+#   DATA_DIR="val_mesh_csv"                        # Training validation (mesh; set HAS_GROUND_TRUTH = false)
+# Testing mode examples:
+#   DATA_DIR="predictions/pred_csv/obs-space/"     # observation-location outputs (with ground truth; set HAS_GROUND_TRUTH = true)
+#   DATA_DIR="predictions/pred_csv/mesh-grid/"     # mesh-grid outputs (forecast only; set HAS_GROUND_TRUTH = false)
+DATA_DIR="predictions/test1-3years/pred_csv/mesh-grid/"
+
+# Output directory for plots
+PLOT_DIR="evaluation/figures/test1-3years/pred_mesh"
+
+# --- Mode Configuration ---
+# Set HAS_GROUND_TRUTH=true for obs-space files, has ground truth
+# Set HAS_GROUND_TRUTH=false for mesh-grid files, no ground truth
+HAS_GROUND_TRUTH=false
+
+# --- Date Range for Batch Processing ---
+START_DATE=${1:-"2025030100"}
+END_DATE=${2:-"2025030112"}
+FHR_LIST=(6 12)
+# Examples:
+#   FHR_LIST=("")        # obs-space data (always empty)
+#   FHR_LIST=(3)         # mesh-grid data: Single forecast hour
+#   FHR_LIST=(3 6 9 12)  # mesh-grid data: All forecast hours
+
+# ============================================
+
+# Check required script exists
+if [ "$MODE" == "gfs_compare" ]; then
+    if [ ! -f "$GFS_COMPARE_SCRIPT" ]; then
+        echo "Error: $GFS_COMPARE_SCRIPT not found!"
+        exit 1
+    fi
+else
+    if [ ! -f "$EVAL_SCRIPT" ]; then
+        echo "Error: $EVAL_SCRIPT not found!"
+        exit 1
+    fi
+fi
+
+# Validate date format (YYYYMMDDHH)
+# Note: In [[ ]], the =~ operator needs a space before and after it,
+# but the regex itself should NOT have spaces in the middle of it.
+if [[ ! "$START_DATE" =~ ^[0-9]{10}$ ]] || [[ ! "$END_DATE" =~ ^[0-9]{10}$ ]]; then
+    echo "Error: Dates must be in format YYYYMMDDHH"
+    echo "Usage: $0 START_DATE END_DATE"
+    echo "Example: $0 2023010100 2023010912"
+    exit 1
+fi
+
+echo ""
+echo "Configuration:"
+echo "  Evaluation script: $EVAL_SCRIPT"
+echo "  Start date: $START_DATE"
+echo "  End date: $END_DATE"
+echo "  Forecast hours: ${FHR_LIST[@]}"
+echo "  Data directory: $DATA_DIR"
+echo "  Plot directory: $PLOT_DIR"
+echo "  Has ground truth?: $HAS_GROUND_TRUTH"
+echo "  Mode: $MODE"
+if [ "$MODE" == "gfs_compare" ]; then
+    echo "  Instrument: $INSTRUMENT"
+    echo "  Chunksize: $CHUNKSIZE"
+    echo "  Vars: $VARS"
+fi
+
+# Fixed: Added spaces inside [ ] brackets
+if [ -n "$EPOCH_TO_PLOT" ]; then
+    echo "  Epoch: $EPOCH_TO_PLOT"
+fi
+
+if [ -n "$BATCH_IDX_TO_PLOT" ]; then
+    echo "  Batch index: $BATCH_IDX_TO_PLOT"
+fi
+
+echo "  Python path: $PYTHONPATH"
+echo "================================================"
+echo ""
+
+# Convert YYYYMMDDHH to epoch seconds for comparison
+# Fixed: Removed spaces around = and inside the date/format flags
+START_TIME=$(date -d "${START_DATE:0:8} ${START_DATE:8:2}:00:00" +%s)
+END_TIME=$(date -d "${END_DATE:0:8} ${END_DATE:8:2}:00:00" +%s)
+
+# Initialize counters - Fixed: Removed spaces around =
+CURRENT_TIME=$START_TIME
+TOTAL_RUNS=0
+SUCCESS_RUNS=0
+FAILED_RUNS=0
+
+# Loop through dates with 12-hour increments
+# Fixed: Added spaces inside [ ] and removed space in -le
+while [ $CURRENT_TIME -le $END_TIME ]
+do
+    # Convert epoch back to YYYYMMDDHH format
+    # Fixed: Removed spaces around =, corrected date format strings
+    INIT_TIME=$(date -d "@$CURRENT_TIME" +%Y%m%d%H)
+    DISPLAY_DATE=$(date -d "@$CURRENT_TIME" +"%Y-%m-%d %H:%M")
+
+    echo "----------------------------------------"
+    echo "Processing init time: $DISPLAY_DATE ($INIT_TIME)"
+    echo "----------------------------------------"
+
+    # Loop through each forecast hour
+    for FHR in "${FHR_LIST[@]}"
+    do
+        TOTAL_RUNS=$((TOTAL_RUNS + 1))
+
+        echo ""
+        if [ -n "$FHR" ]; then
+            echo "  Running: init_time=$INIT_TIME, fhr=$FHR"
+        else
+            echo "  Running: init_time=$INIT_TIME (no fhr)"
+        fi
+
+        # Build Python command
+        if [ "$MODE" == "gfs_compare" ]; then
+            # Plots RMSE vs forecast hour from *_vs_gfs.csv
+            CMD="python $GFS_COMPARE_SCRIPT --init_time $INIT_TIME --data_dir $DATA_DIR --plot_dir $PLOT_DIR --instrument $INSTRUMENT --vars $VARS --chunksize $CHUNKSIZE"
+        else
+            # Standard evaluation plots (pred vs truth)
+            CMD="python $EVAL_SCRIPT --init_time $INIT_TIME --data_dir $DATA_DIR --plot_dir $PLOT_DIR"
+        fi
+
+        if [ -n "$FHR" ] && [ "$MODE" != "gfs_compare" ]; then
+            CMD="$CMD --fhr $FHR"
+        fi
+
+        # Fixed: Comparison for strings usually needs == and HAS_GROUND_TRUTH was set to "true" earlier
+        if [ "$HAS_GROUND_TRUTH" == "true" ] && [ "$MODE" != "gfs_compare" ]; then
+            CMD="$CMD --has_ground_truth"
+        fi
+
+        if [ -n "$EPOCH_TO_PLOT" ]; then
+            CMD="$CMD --epoch $EPOCH_TO_PLOT"
+        fi
+        
+        if [ -n "$BATCH_IDX_TO_PLOT" ]; then
+            CMD="$CMD --batch_idx $BATCH_IDX_TO_PLOT"
+        fi
+
+        # Run Python script
+        # Note: eval is used here to properly interpret the string as a command
+        if eval $CMD; then
+            SUCCESS_RUNS=$((SUCCESS_RUNS + 1))
+            if [ -n "$FHR" ]; then
+                echo "Success: init_time=$INIT_TIME, fhr=$FHR"
+            else
+                echo "Success: init_time=$INIT_TIME (no fhr)"
+            fi
+        else
+            FAILED_RUNS=$((FAILED_RUNS + 1))
+            if [ -n "$FHR" ]; then
+                echo "Failed: init_time=$INIT_TIME, fhr=$FHR (continuing...)"
+            else
+                echo "Failed: init_time=$INIT_TIME (no fhr) (continuing...)"
+            fi
+        fi
+    done
+
+    echo ""
+    # Increment by 12 hours (43200 seconds)
+    CURRENT_TIME=$((CURRENT_TIME + 43200))
+done
+
+echo "================================================"
+echo "Batch evaluation complete"
+echo "Total runs: $TOTAL_RUNS"
+echo "Successful: $SUCCESS_RUNS"
+echo "Failed: $FAILED_RUNS"
+echo "End time: $(date)"
+echo "================================================"
+
+# Exit with error if any runs failed
+if [ $FAILED_RUNS -gt 0 ]; then
+    echo "WARNING: Some runs failed. Check output for details."
+    exit 1
+fi

--- a/gnn_model/evaluation/scripts/run_mesh_gfs_compare.sh
+++ b/gnn_model/evaluation/scripts/run_mesh_gfs_compare.sh
@@ -1,0 +1,130 @@
+#!/bin/bash -l
+#SBATCH -A gpu-emc-ai
+#SBATCH -p u1-h100
+#SBATCH -q gpu
+#SBATCH --gres=gpu:h100:1
+#SBATCH -J mesh_gfs_compare
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=0
+#SBATCH -t 01:00:00
+#SBATCH --output=mesh_gfs_compare_%j.out
+#SBATCH --error=mesh_gfs_compare_%j.err
+#SBATCH --mail-type=BEGIN,END,FAIL
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GNN_MODEL_DIR="/scratch3/NCEPDEV/da/Mu-Chieh.Ko/OCELOT/MAIN/main260403/ocelot/gnn_model"  # "$(cd "${SCRIPT_DIR}/../.." && pwd)"
+OCELOT_DIR="$(cd "${GNN_MODEL_DIR}/.." && pwd)"
+
+cd "${SLURM_SUBMIT_DIR:-${GNN_MODEL_DIR}}"
+
+# =====================
+# User-config parameters
+# =====================
+
+INIT_TIME=${INIT_TIME:-2025030100}
+INSTRUMENT_LIST=${INSTRUMENT_LIST:-"surface_obs radiosonde"}
+EXP_NAME=${EXP_NAME:-ep1808_sdate0228}
+FHR_LIST=${FHR_LIST:-"3 6 9 12"}
+GFS_ROOT=${GFS_ROOT:-/scratch3/NCEPDEV/da/Mu-Chieh.Ko/JEDI-nudging/gfs-rt25}
+
+OUT_ROOT=${OUT_ROOT:-"predictions/${EXP_NAME}"}
+MESH_DIR=${OUT_ROOT}/pred_csv/mesh-grid
+PLOT_ROOT="evaluation/${OUT_ROOT}/figures"
+PLOT_MESH_GFS_DIR=${PLOT_ROOT}/mesh_ocelot_gfs_gfs0/init_${INIT_TIME}
+
+CODE_ROOT="/scratch3/NCEPDEV/da/Mu-Chieh.Ko/OCELOT/DEV/evaluation/ocelot/gnn_model/evaluation/scripts/"
+COMPARE_MESH_TO_GFS_SCRIPT=${CODE_ROOT}/compare_mesh_to_gfs_update.py
+PLOT_MESH_VS_GFS_MAPS_SCRIPT=${CODE_ROOT}/plot_mesh_vs_gfs_maps_update.py
+
+echo "Running on $(hostname)"
+echo "INIT_TIME=${INIT_TIME}"
+echo "INSTRUMENT_LIST=${INSTRUMENT_LIST}"
+echo "EXP_NAME=${EXP_NAME}"
+echo "FHR_LIST=${FHR_LIST}"
+echo "GFS_ROOT=${GFS_ROOT}"
+echo "MESH_DIR=${MESH_DIR}"
+echo "PLOT_MESH_GFS_DIR=${PLOT_MESH_GFS_DIR}"
+
+# Conda
+source /scratch3/NCEPDEV/da/Azadeh.Gholoubi/miniconda3/etc/profile.d/conda.sh
+conda activate gnn-env
+
+export PYTHONPATH="${GNN_MODEL_DIR}:${OCELOT_DIR}:${PYTHONPATH:-}"
+
+# =====================
+# Mesh-grid: interpolate GFS forecast + analysis onto OCELOT mesh points
+# =====================
+
+echo "==== Mesh-grid: interpolate GFS onto OCELOT mesh grid (same points) ===="
+if [ ! -d "${MESH_DIR}" ]; then
+  echo "[WARN] Mesh-grid directory not found: ${MESH_DIR}"
+  exit 0
+fi
+
+for INSTRUMENT in ${INSTRUMENT_LIST}; do
+  echo "---- Instrument: ${INSTRUMENT} ----"
+
+  shopt -s nullglob
+  mesh_matches=("${MESH_DIR}/${INSTRUMENT}_init_${INIT_TIME}_f"*.csv)
+  filtered_matches=()
+  for mesh_path in "${mesh_matches[@]}"; do
+    case "${mesh_path}" in
+      *_gfs_on_ocelot_mesh.csv) ;;
+      *) filtered_matches+=("${mesh_path}") ;;
+    esac
+  done
+  shopt -u nullglob
+
+  if [ ${#filtered_matches[@]} -eq 0 ]; then
+    echo "[INFO] No mesh-grid prediction CSVs found for instrument=${INSTRUMENT} init=${INIT_TIME}; skipping."
+    echo "[INFO] Mesh-grid files are only produced when prediction runs with enable_mesh_pred: true."
+    continue
+  fi
+
+  for fhr in ${FHR_LIST}; do
+    mesh_csv="${MESH_DIR}/${INSTRUMENT}_init_${INIT_TIME}_f$(printf '%03d' ${fhr}).csv"
+    gfs_on_ocelot_mesh_csv="${MESH_DIR}/${INSTRUMENT}_init_${INIT_TIME}_f$(printf '%03d' ${fhr})_gfs_on_ocelot_mesh.csv"
+
+    if [ -f "${mesh_csv}" ]; then
+      # Fail fast: require mesh_idx so we can guarantee strict alignment across mesh products.
+      if ! head -n 1 "${mesh_csv}" | tr ',' '\n' | grep -qx "mesh_idx"; then
+        echo "ERROR: mesh-grid CSV is missing mesh_idx (old format): ${mesh_csv}"
+        echo "Re-run prediction with the updated code that writes mesh_idx."
+        exit 4
+      fi
+
+      echo "[INFO] Building mesh-vs-GFS CSV for instrument=${INSTRUMENT} fhr=${fhr}"
+      python "${COMPARE_MESH_TO_GFS_SCRIPT}" \
+        --mesh_csv "${mesh_csv}" \
+        --gfs_root "${GFS_ROOT}" \
+        --out_csv "${gfs_on_ocelot_mesh_csv}" \
+        --interp nearest
+
+      # Plot variables appropriate for the instrument.
+      mkdir -p "${PLOT_MESH_GFS_DIR}/fhr${fhr}"
+      if [ "${INSTRUMENT}" == "radiosonde" ]; then
+        mesh_vars="u v temp"
+      else
+        mesh_vars="u10 v10 t2m sp"
+      fi
+      for v in ${mesh_vars}; do
+        python "${PLOT_MESH_VS_GFS_MAPS_SCRIPT}" \
+          --csv "${gfs_on_ocelot_mesh_csv}" \
+          --plot_dir "${PLOT_MESH_GFS_DIR}/fhr${fhr}" \
+          --var "${v}" \
+          --gfs_root "${GFS_ROOT}" || true
+      done
+    else
+      echo "[WARN] Mesh-grid CSV not found for fhr=${fhr}: ${mesh_csv}"
+    fi
+  done
+
+done
+
+echo "DONE. Outputs:"
+echo "  Mesh CSVs:   ${MESH_DIR}"
+echo "  Mesh vs GFS: ${PLOT_MESH_GFS_DIR}"

--- a/gnn_model/evaluation/scripts/run_mesh_gfs_compare.sh
+++ b/gnn_model/evaluation/scripts/run_mesh_gfs_compare.sh
@@ -1,13 +1,11 @@
 #!/bin/bash -l
-#SBATCH -A gpu-emc-ai
-#SBATCH -p u1-h100
-#SBATCH -q gpu
-#SBATCH --gres=gpu:h100:1
+#SBATCH -A da-cpu
+#SBATCH -p u1-service
 #SBATCH -J mesh_gfs_compare
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=4
-#SBATCH --mem=0
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=32G
 #SBATCH -t 01:00:00
 #SBATCH --output=mesh_gfs_compare_%j.out
 #SBATCH --error=mesh_gfs_compare_%j.err
@@ -15,8 +13,9 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-GNN_MODEL_DIR="/scratch3/NCEPDEV/da/Mu-Chieh.Ko/OCELOT/MAIN/main260403/ocelot/gnn_model"  # "$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="/scratch3/NCEPDEV/da/Mu-Chieh.Ko/OCELOT/DEV/recover_mesh_attr/ocelot/gnn_model/evaluation/scripts/"
+GNN_MODEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 OCELOT_DIR="$(cd "${GNN_MODEL_DIR}/.." && pwd)"
 
 cd "${SLURM_SUBMIT_DIR:-${GNN_MODEL_DIR}}"
@@ -27,18 +26,17 @@ cd "${SLURM_SUBMIT_DIR:-${GNN_MODEL_DIR}}"
 
 INIT_TIME=${INIT_TIME:-2025030100}
 INSTRUMENT_LIST=${INSTRUMENT_LIST:-"surface_obs radiosonde"}
-EXP_NAME=${EXP_NAME:-ep1808_sdate0228}
+EXP_NAME=${EXP_NAME:-test1-3years}
 FHR_LIST=${FHR_LIST:-"3 6 9 12"}
 GFS_ROOT=${GFS_ROOT:-/scratch3/NCEPDEV/da/Mu-Chieh.Ko/JEDI-nudging/gfs-rt25}
 
 OUT_ROOT=${OUT_ROOT:-"predictions/${EXP_NAME}"}
 MESH_DIR=${OUT_ROOT}/pred_csv/mesh-grid
-PLOT_ROOT="evaluation/${OUT_ROOT}/figures"
+PLOT_ROOT="evaluation/figures/${EXP_NAME}"
 PLOT_MESH_GFS_DIR=${PLOT_ROOT}/mesh_ocelot_gfs_gfs0/init_${INIT_TIME}
 
-CODE_ROOT="/scratch3/NCEPDEV/da/Mu-Chieh.Ko/OCELOT/DEV/evaluation/ocelot/gnn_model/evaluation/scripts/"
-COMPARE_MESH_TO_GFS_SCRIPT=${CODE_ROOT}/compare_mesh_to_gfs_update.py
-PLOT_MESH_VS_GFS_MAPS_SCRIPT=${CODE_ROOT}/plot_mesh_vs_gfs_maps_update.py
+COMPARE_MESH_TO_GFS_SCRIPT=${SCRIPT_DIR}/compare_mesh_to_gfs_update.py
+PLOT_MESH_VS_GFS_MAPS_SCRIPT=${SCRIPT_DIR}/plot_mesh_vs_gfs_maps_update.py
 
 echo "Running on $(hostname)"
 echo "INIT_TIME=${INIT_TIME}"

--- a/gnn_model/evaluation/scripts/run_mesh_gfs_compare.sh
+++ b/gnn_model/evaluation/scripts/run_mesh_gfs_compare.sh
@@ -13,8 +13,7 @@
 
 set -euo pipefail
 
-# SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPT_DIR="/scratch3/NCEPDEV/da/Mu-Chieh.Ko/OCELOT/DEV/recover_mesh_attr/ocelot/gnn_model/evaluation/scripts/"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GNN_MODEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 OCELOT_DIR="$(cd "${GNN_MODEL_DIR}/.." && pwd)"
 

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -2601,9 +2601,9 @@ class GNNLightning(pl.LightningModule):
                 # Decode each step
                 for step_idx, mesh_feat in enumerate(mesh_features_per_step):
                     pred = self._decode_one_step_to_mesh(mesh_feat, inst_name, mesh_pred_edges[inst_name],
-                            step_idx=step_idx,
-                            init_time_unix=init_time_unix
-                           )
+                                                         step_idx=step_idx,
+                                                         init_time_unix=init_time_unix
+                                                         )
                     predictions[inst_name].append(pred)
 
         return predictions
@@ -2796,7 +2796,7 @@ class GNNLightning(pl.LightningModule):
                     else:
                         mesh_pred_edges = self._get_mesh_pred_edges()
                         init_time_unix = self._extract_init_time_unix(batch)
-                        mesh_predictions = self._decode_all_steps_to_mesh(mesh_features_per_step, mesh_pred_edges,init_time_unix)
+                        mesh_predictions = self._decode_all_steps_to_mesh(mesh_features_per_step, mesh_pred_edges, init_time_unix)
                         if mesh_predictions:
                             mesh_dir = os.path.join(self._prediction_output_dir, 'pred_csv', 'mesh-grid')
                             self._save_mesh_predictions(

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -2670,7 +2670,7 @@ class GNNLightning(pl.LightningModule):
             )
 
         # Compute valid time = init + lead
-        lead_seconds = int(step_idx * self.latent_step_hours * 3600)
+        lead_seconds = int(round((step_idx + 0.5) * self.latent_step_hours * 3600))
         target_time_unix = int(int(init_time_unix) + lead_seconds)
 
         # Build time features using the same convention as _encode_target_time_features()

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -33,6 +33,8 @@ from loss import weighted_huber_loss, weighted_mse_loss
 from processor_transformer import SlidingWindowTransformerProcessor
 from processor_transformer_hierarchical import HierarchicalSlidingWindowTransformer
 from attn_bipartite import BipartiteGAT
+from process_timeseries import _encode_target_time_features
+from datetime import datetime
 
 
 def _build_instrument_map(observation_config: dict) -> dict[str, int]:
@@ -724,10 +726,30 @@ class GNNLightning(pl.LightningModule):
 
             print(f"[MESH PRED] {inst_name}: {edge_index.shape[1]} edges")
 
+            edge_attr_key = f'{inst_name}_edge_attr'
+            if edge_attr_key in data:
+                edge_attr = torch.from_numpy(data[edge_attr_key]).float()
+                if edge_attr.shape[0] != edge_index.shape[1]:
+                    raise ValueError(
+                        f"[MESH PRED] {inst_name}: edge_attr row count ({edge_attr.shape[0]}) "
+                        f"!= edge_index edge count ({edge_index.shape[1]})"
+                    )
+                if edge_attr.shape[1] != self.bipartite_edge_attr_dim:
+                    raise ValueError(
+                        f"[MESH PRED] {inst_name}: edge_attr dim ({edge_attr.shape[1]}) "
+                        f"!= bipartite_edge_attr_dim ({self.bipartite_edge_attr_dim})"
+                    )
+            else:
+                print(
+                    f"[MESH PRED] WARNING: No edge_attr found for {inst_name} in {edges_path}. "
+                    f"Falling back to zeros — re-run precompute_mesh_edges.py to fix this."
+                )
+                edge_attr = torch.zeros((edge_index.size(1), self.bipartite_edge_attr_dim))
+
             # Store on CPU - will move to device when used
             mesh_pred_edges[inst_name] = {
                 'edge_index': edge_index,  # CPU tensor (no .to(device))
-                'edge_attr': torch.zeros((edge_index.size(1), self.bipartite_edge_attr_dim)),  # CPU
+                'edge_attr': edge_attr,
                 'lats': torch.from_numpy(mesh_lats).float(),  # CPU
                 'lons': torch.from_numpy(mesh_lons).float(),  # CPU
                 'num_nodes': num_nodes
@@ -2040,9 +2062,11 @@ class GNNLightning(pl.LightningModule):
         try:
             with torch.no_grad():
                 temp_mesh_pred_edges = self._get_mesh_pred_edges()
+                init_time_unix = self._extract_init_time_unix(self._last_val_batch)
                 mesh_predictions = self._decode_all_steps_to_mesh(
                     self._last_val_mesh_features,
-                    temp_mesh_pred_edges
+                    temp_mesh_pred_edges,
+                    init_time_unix
                 )
                 if mesh_predictions:
                     self._save_mesh_predictions(
@@ -2063,75 +2087,57 @@ class GNNLightning(pl.LightningModule):
             self._last_val_mesh_features = None
             self._last_val_batch = None
 
-    def _extract_init_time_str(self, batch):
-        """
-        Extract initialization time string from batch in YYYYMMDDHH format.
-        Handles multiple formats: pandas Timestamp, list/tuple, Unix timestamp, tensor.
-
-        Args:
-            batch: Batch data containing input_time or time attribute
-
-        Returns:
-            str: Init time as 'YYYYMMDDHH' or 'unknown' if unavailable
-        """
-        from datetime import datetime
-        import pandas as pd
-
-        if batch is None:
-            return 'unknown'
-
-        # Prefer forecast init (start of target window) when available.
-        # `GNNDataModule` attaches:
-        # - init_time: start of the target window (forecast init / cycle time)
-        # - input_time: start of the input window
-        ts = None
-
-        def _pick_attr(name: str):
+    def _resolve_init_ts(self, batch):
+        """Return raw init timestamp (int/float unix, pd.Timestamp, or datetime), or None."""
+        def _pick_attr(name):
             if not hasattr(batch, name):
                 return None
             v = getattr(batch, name)
+            if isinstance(v, (list, tuple)):
+                v = v[0] if len(v) > 0 else None
             if v is None:
                 return None
-            if isinstance(v, (list, tuple)):
-                return v[0] if len(v) > 0 else None
             # Treat scalar tensors and numeric sentinels as missing.
             if hasattr(v, 'item'):
                 try:
                     vv = v.item()
-                    if isinstance(vv, (int, float)) and float(vv) < 0:
-                        return None
-                    return vv
+                    return None if float(vv) < 0 else vv
                 except Exception:
-                    return v
-            if isinstance(v, (int, float)) and float(v) < 0:
-                return None
-            return v
+                    return None
+            return None if isinstance(v, (int, float)) and float(v) < 0 else v
 
         init_ts = _pick_attr('init_time')
         input_ts = _pick_attr('input_time')
         time_ts = _pick_attr('time')
 
         if init_ts is not None:
-            ts = init_ts
+            return init_ts
         elif input_ts is not None:
-            # In inference mode the datamodule may not populate init_time (no targets).
-            # In our binning logic, input_time is the *start* of the input window, so
-            # forecast init ≈ input_time + data_window_hours.
             try:
                 window_h = self.hparams.get('data_window_hours', None)
                 if window_h is not None and isinstance(window_h, (int, float)):
-                    ts = float(input_ts) + float(window_h) * 3600.0
+                    return float(input_ts) + float(window_h) * 3600.0
                 else:
-                    ts = input_ts
+                    return input_ts
             except Exception:
-                ts = input_ts
+                return input_ts
         else:
-            ts = time_ts
+            return time_ts
 
-        # Now convert ts to string based on its type
+    def _extract_init_time_str(self, batch):
+        """
+        Extract initialization time string from batch in YYYYMMDDHH format.
+        Args:
+            batch: Batch data containing input_time or time attribute
+
+        Returns:
+            str: Init time as 'YYYYMMDDHH' or 'unknown' if unavailable
+        """
+        if batch is None:
+            return 'unknown'
+        ts = self._resolve_init_ts(batch)
         if ts is None:
             return 'unknown'
-
         try:
             # Handle pandas Timestamp
             if isinstance(ts, pd.Timestamp):
@@ -2153,6 +2159,20 @@ class GNNLightning(pl.LightningModule):
         except Exception as e:
             print(f"[INIT_TIME] Error converting time: {e}, type: {type(ts)}")
             return 'unknown'
+
+    def _extract_init_time_unix(self, batch) -> int:
+        ts = self._resolve_init_ts(batch)
+        if ts is None:
+            raise ValueError(
+                "[MESH PRED] Cannot determine init_time_unix from batch — "
+                "batch has no valid init_time or input_time. "
+                "Target-time conditioning requires a valid analysis time."
+            )
+        if isinstance(ts, pd.Timestamp):
+            return int(ts.timestamp())
+        if isinstance(ts, datetime):
+            return int(ts.timestamp())
+        return int(float(ts))
 
     def _save_latent_concatenated_csv(self, batch, node_type, preds_list, gts_list,
                                       valid_mask_list, out_dir, batch_idx, mode='val'):
@@ -2559,7 +2579,7 @@ class GNNLightning(pl.LightningModule):
                 df.to_csv(filepath, index=False)
                 print(f"[MESH PRED] Saved {filepath}: {len(df)} points")
 
-    def _decode_all_steps_to_mesh(self, mesh_features_per_step, mesh_pred_edges):
+    def _decode_all_steps_to_mesh(self, mesh_features_per_step, mesh_pred_edges, init_time_unix):
         """Decode all forecast steps to mesh grid."""
 
         if not mesh_features_per_step:  # Check if the list is empty
@@ -2580,12 +2600,15 @@ class GNNLightning(pl.LightningModule):
 
                 # Decode each step
                 for step_idx, mesh_feat in enumerate(mesh_features_per_step):
-                    pred = self._decode_one_step_to_mesh(mesh_feat, inst_name, mesh_pred_edges[inst_name])
+                    pred = self._decode_one_step_to_mesh(mesh_feat, inst_name, mesh_pred_edges[inst_name],
+                            step_idx=step_idx,
+                            init_time_unix=init_time_unix
+                           )
                     predictions[inst_name].append(pred)
 
         return predictions
 
-    def _decode_one_step_to_mesh(self, mesh_features, inst_name, edges):
+    def _decode_one_step_to_mesh(self, mesh_features, inst_name, edges, step_idx, init_time_unix=None):
         """Decode one step's mesh features to mesh grid."""
         # Get decoder
         decoder_key = f"mesh__to__{inst_name}_target"
@@ -2626,6 +2649,27 @@ class GNNLightning(pl.LightningModule):
             # Satellites, surface obs etc.: no pressure conditioning (same as training)
             rec_rep = torch.zeros(N, self.hidden_dim, device=device)
             print(f"[MESH PRED] Decoding {inst_name} with zero initialization (no pressure conditioning)")
+
+        # --- Target-time conditioning (mirrors regular decoder) ---
+        if init_time_unix is None:
+            raise ValueError(
+                f"[MESH PRED] init_time_unix is required for target-time conditioning "
+                f"but was not provided for instrument '{inst_name}'. "
+                f"Pass the analysis time as a Unix timestamp when calling mesh prediction."
+            )
+
+        # Compute valid time = init + lead
+        lead_seconds = step_idx * self.latent_step_hours * 3600
+        target_time_unix = int(init_time_unix) + lead_seconds
+
+        # Build time features using the same convention as _encode_target_time_features()
+        # LST is estimated from mesh node longitude
+        lons_deg = edges['lons'].cpu().numpy()  # [N]
+        target_times_unix = np.full(N, target_time_unix, dtype=np.int64)
+        time_feat_np = _encode_target_time_features(target_times_unix, lons_deg)  # [N, 5]
+        time_feat = torch.from_numpy(time_feat_np).float().to(device)
+        time_emb = self.target_time_embedder(time_feat)  # [N, 8]
+        rec_rep = rec_rep + self.target_time_projector(time_emb)  # additive bias
 
         # Decode
         decoded = decoder(
@@ -2751,7 +2795,8 @@ class GNNLightning(pl.LightningModule):
                         print("[PREDICT] No mesh features available for mesh predictions")
                     else:
                         mesh_pred_edges = self._get_mesh_pred_edges()
-                        mesh_predictions = self._decode_all_steps_to_mesh(mesh_features_per_step, mesh_pred_edges)
+                        init_time_unix = self._extract_init_time_unix(batch)
+                        mesh_predictions = self._decode_all_steps_to_mesh(mesh_features_per_step, mesh_pred_edges,init_time_unix)
                         if mesh_predictions:
                             mesh_dir = os.path.join(self._prediction_output_dir, 'pred_csv', 'mesh-grid')
                             self._save_mesh_predictions(

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -2097,13 +2097,24 @@ class GNNLightning(pl.LightningModule):
                 v = v[0] if len(v) > 0 else None
             if v is None:
                 return None
-            # Treat scalar tensors and numeric sentinels as missing.
+
             if hasattr(v, 'item'):
                 try:
+                    if hasattr(v, 'numel') and v.numel() > 1:
+                        flat = v.reshape(-1)
+                        if not torch.all(flat == flat[0]):
+                            import warnings
+                            warnings.warn(
+                                f"[_pick_attr] '{name}' has {v.numel()} non-identical "
+                                f"values; using first ({flat[0].item()!r}) for timestamp.",
+                                RuntimeWarning, stacklevel=2,
+                            )
+                        v = flat[0]
                     vv = v.item()
                     return None if float(vv) < 0 else vv
                 except Exception:
                     return None
+
             return None if isinstance(v, (int, float)) and float(v) < 0 else v
 
         init_ts = _pick_attr('init_time')
@@ -2659,8 +2670,8 @@ class GNNLightning(pl.LightningModule):
             )
 
         # Compute valid time = init + lead
-        lead_seconds = step_idx * self.latent_step_hours * 3600
-        target_time_unix = int(init_time_unix) + lead_seconds
+        lead_seconds = int(step_idx * self.latent_step_hours * 3600)
+        target_time_unix = int(int(init_time_unix) + lead_seconds)
 
         # Build time features using the same convention as _encode_target_time_features()
         # LST is estimated from mesh node longitude

--- a/gnn_model/precompute_mesh_edges.py
+++ b/gnn_model/precompute_mesh_edges.py
@@ -77,11 +77,14 @@ def precompute_edges(mesh_config_path, output_path, mesh_resolution=6):
 
     # Convert to numpy once and reuse for each instrument
     edge_index_np = edge_index.cpu().numpy()
+    edge_attr_np = edge_attr.cpu().numpy()
     for inst_name in mesh_instruments:
         print(f"\nStoring edges for {inst_name}...")
         # Use the same mesh→grid edges for each instrument
         edges_data[f'{inst_name}_edge_index'] = edge_index_np
-        # Note: We don't save edge_attr because model creates zeros with hidden_dim
+        edges_data[f'{inst_name}_edge_attr'] = edge_attr_np
+        # Note: edge_attr contains 4D GraphCast-style spatial features
+        # These are consumed by BipartiteGAT with edge_dim=bipartite_edge_attr_dim
 
     # Save to file
     print(f"\nSaving to {output_path}...")

--- a/gnn_model/run_pred.sh
+++ b/gnn_model/run_pred.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 #SBATCH --exclude=u22g09,u22g08,u22g10,u23g12
-#SBATCH -A gpu-emc-ai
+#SBATCH -A gpu-emc-ai  # ai4ep; emc-ai
 #SBATCH -p u1-h100
 #SBATCH -q gpu
 #SBATCH --gres=gpu:h100:1
@@ -22,31 +22,14 @@ echo "Architecture: $(uname -m)"
 source /scratch3/NCEPDEV/da/Azadeh.Gholoubi/miniconda3/etc/profile.d/conda.sh
 conda activate gnn-env
 
-# Debug + performance
-# export NCCL_DEBUG=INFO
-# export NCCL_DEBUG_SUBSYS=INIT,NET
-export TORCH_NCCL_BLOCKING_WAIT=1          # explicit
-export NCCL_SHM_DISABLE=1                  # avoid shm edge cases
-export NCCL_NET_GDR_LEVEL=PHB              # conservative GPUDirect setting
-export NCCL_IB_DISABLE=0
-export OMP_NUM_THREADS=1
-export PYTORCH_ENABLE_MPS_FALLBACK=1
-export NCCL_SOCKET_IFNAME=ib0
-export NCCL_IB_DISABLE=0
-export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
-export NCCL_P2P_LEVEL=NVL
-export PYTHONFAULTHANDLER=1
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GNN_MODEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+OCELOT_DIR="$(cd "${GNN_MODEL_DIR}/.." && pwd)"
 
-# Fix distributed timeout issues
-export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=3600    # 1 hour timeout
-export TORCH_NCCL_DESYNC_DEBUG=1                # Better error reporting  
-export NCCL_TIMEOUT=3600                        # NCCL timeout 1 hour
-export TORCH_DISTRIBUTED_DEBUG=OFF # INFO
-# export CUDA_LAUNCH_BLOCKING=1
-export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-# Local NNJA mirror (shared path visible to ALL nodes)
-export NNJA_LOCAL_ROOT=/scratch3/NCEPDEV/da/Azadeh.Gholoubi/NNJA/nnja-ai
-export PYTHONPATH=/scratch3/NCEPDEV/da/Azadeh.Gholoubi/NNJA/ocelot/gnn_model:/scratch3/NCEPDEV/da/Azadeh.Gholoubi/NNJA/ocelot:$PYTHONPATH
+cd "${SLURM_SUBMIT_DIR:-${GNN_MODEL_DIR}}"
+
+# Ensure we run the code from THIS checkout (not NNJA mirror)
+export PYTHONPATH="${GNN_MODEL_DIR}:${OCELOT_DIR}:${PYTHONPATH:-}"
 
 echo "Running on $(hostname)"
 echo "SLURM Node List: $SLURM_NODELIST"
@@ -54,11 +37,12 @@ echo "Visible GPUs on this node:"
 nvidia-smi
 
 # Prediction mode:
+    #--checkpoint /scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/mainBranch/ocelot/gnn_model/checkpoints/Rand_TenYear_nl16/gnn-epoch-epoch=364-val_loss-val_loss=0.15.ckpt \
 srun --export=ALL --kill-on-bad-exit=1 --cpu-bind=cores python predict_gnn.py \
-    --checkpoint /scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/mainBranch/ocelot/gnn_model/checkpoints/Rand_TenYear_nl16/gnn-epoch-epoch=364-val_loss-val_loss=0.15.ckpt \
-    --start_date 2025-03-01 \
+    --checkpoint /scratch3/NCEPDEV/da/Mu-Chieh.Ko/OCELOT/MAIN/main260429/ocelot/gnn_model/checkpoints/test1-3years/ep181.ckpt \
+    --start_date 2025-02-28 \
     --end_date 2025-03-03 \
-    --output_dir predictions \
+    --output_dir predictions/test1-3years \
     --eval-mode  # comment out to run in inference mode
     # Evaluation mode: Predict on obs-space for all instruments (AMSUA, aircraft, etc.) with ground truth comparisons.
     #                  The last timebin is held as the target bin, consistent with training.

--- a/gnn_model/run_pred.sh
+++ b/gnn_model/run_pred.sh
@@ -42,7 +42,7 @@ CKPT="checkpoints/$EXPT/ep181.ckpt"
 OUT_DIR="predictions/$EXPT"
 
 srun --export=ALL --kill-on-bad-exit=1 --cpu-bind=cores python predict_gnn.py \
-    --checkpoint $CKPT
+    --checkpoint $CKPT \
     --start_date 2025-02-28 \
     --end_date 2025-03-03 \
     --output_dir $OUTDIR \

--- a/gnn_model/run_pred.sh
+++ b/gnn_model/run_pred.sh
@@ -37,12 +37,15 @@ echo "Visible GPUs on this node:"
 nvidia-smi
 
 # Prediction mode:
-    #--checkpoint /scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/mainBranch/ocelot/gnn_model/checkpoints/Rand_TenYear_nl16/gnn-epoch-epoch=364-val_loss-val_loss=0.15.ckpt \
+EXPT="test1-3years"
+CKPT="checkpoints/$EXPT/ep181.ckpt"
+OUT_DIR="predictions/$EXPT"
+
 srun --export=ALL --kill-on-bad-exit=1 --cpu-bind=cores python predict_gnn.py \
-    --checkpoint /scratch3/NCEPDEV/da/Mu-Chieh.Ko/OCELOT/MAIN/main260429/ocelot/gnn_model/checkpoints/test1-3years/ep181.ckpt \
+    --checkpoint $CKPT
     --start_date 2025-02-28 \
     --end_date 2025-03-03 \
-    --output_dir predictions/test1-3years \
+    --output_dir $OUTDIR \
     --eval-mode  # comment out to run in inference mode
     # Evaluation mode: Predict on obs-space for all instruments (AMSUA, aircraft, etc.) with ground truth comparisons.
     #                  The last timebin is held as the target bin, consistent with training.

--- a/gnn_model/run_pred.sh
+++ b/gnn_model/run_pred.sh
@@ -45,7 +45,7 @@ srun --export=ALL --kill-on-bad-exit=1 --cpu-bind=cores python predict_gnn.py \
     --checkpoint $CKPT \
     --start_date 2025-02-28 \
     --end_date 2025-03-03 \
-    --output_dir $OUTDIR \
+    --output_dir $OUT_DIR \
     --eval-mode  # comment out to run in inference mode
     # Evaluation mode: Predict on obs-space for all instruments (AMSUA, aircraft, etc.) with ground truth comparisons.
     #                  The last timebin is held as the target bin, consistent with training.


### PR DESCRIPTION
### Background
[Issue106](https://github.com/NOAA-EMC/ocelot/issues/106) `precompute_mesh_edges.py` was written when `edge_attr` was unused in the decoder. Since then, `BipartiteGAT` was updated to actively consume spatial edge features (`edge_dim=bipartite_edge_attr_dim=4`), but the mesh prediction path never caught up — it was silently passing all-zeros to the decoder, causing a train/inference mismatch.

### Changes

**`precompute_mesh_edges.py`**
- Added `edge_attr_np = edge_attr.cpu().numpy()` and save `{inst_name}_edge_attr` per instrument to `.npz`
- Updated comment to reflect that `edge_attr` is 4D GraphCast-style spatial features (distance + relative xyz) consumed by `BipartiteGAT`

**`gnn_model.py`**
- `_load_mesh_prediction_edges`: load real `edge_attr` from `.npz` instead of hardcoded zeros; zero-filled fallback with warning retained for backward compatibility with old `.npz` files; strict shape assertions added (`edge_attr.shape[0] == edge_index.shape[1]` and `edge_attr.shape[1] == bipartite_edge_attr_dim`)
- `_resolve_init_ts`: extracted shared timestamp resolution logic (previously duplicated inside `_extract_init_time_str`) into a standalone helper
- `_extract_init_time_str`: refactored to delegate to `_resolve_init_ts`; no logic changes
- `_extract_init_time_unix`: new method — resolves init timestamp as Unix int for time conditioning; raises clear error if unavailable
- `_decode_one_step_to_mesh`: added target-time conditioning mirroring the regular decoder — computes `target_time_unix = init + lead`, builds 5D time features via `_encode_target_time_features` using mesh node longitudes for local solar time, applies additive bias via `target_time_embedder` + `target_time_projector`
- `_decode_all_steps_to_mesh`: added `init_time_unix` parameter, threaded through to `_decode_one_step_to_mesh`
- `predict_step` and `on_validation_epoch_end`: extract `init_time_unix` via `_extract_init_time_unix` and pass to `_decode_all_steps_to_mesh`

**Evaluation & scripts**
- Added evaluation scripts for GFS analysis comparison
- Restored original `run_evaluation.sh`
- Updated `run_pred.sh`: removed NNJA setup

### Validation
- Regenerated `mesh_pred_edges.npz` — verified `edge_attr` shape `(122886, 4)` saved correctly for both `surface_obs` and `radiosonde`
- Ran mesh predictions with same checkpoint before and after — outputs differ as expected (decoder was previously geometry- and time-blind); no retraining required as all changes are inference-time only