### PR TITLE
Add persistence baseline and evaluation workflows

### DIFF
--- a/gnn_model/evaluation/scripts/compare_mesh_to_gfs.py
+++ b/gnn_model/evaluation/scripts/compare_mesh_to_gfs.py
@@ -1,21 +1,27 @@
 #!/usr/bin/env python
-"""Interpolate GFS onto OCELOT mesh-grid prediction points.
+"""Interpolate GFS forecast and GFS analysis onto OCELOT mesh-grid prediction points.
 
 Author: Azadeh Gholoubi
 
 Mesh-grid prediction CSVs are produced when `enable_mesh_pred: true` and should look like:
   <mesh_dir>/<instrument>_init_<YYYYMMDDHH>_f<FFF>.csv
 
-This script reads those mesh CSVs and adds `gfs_*` columns by interpolating the
-corresponding GFS GRIB (0.25°) to the mesh lat/lon points.
+This script reads those mesh CSVs and adds:
+  - `gfs_*` columns: GFS forecast interpolated to the OCELOT mesh points.
+  - `anl_*` columns: GFS f000 analysis interpolated to the same points.
+
+Analysis is added only when the valid time is on a native 6-hourly GFS analysis
+cycle (00/06/12/18Z). For example, a 00Z init gets analysis at f006 and f012,
+but not f003 or f009.
 
 Output is a CSV per lead time:
     <out_dir>/<instrument>_init_<YYYYMMDDHH>_f<FFF>_gfs_on_ocelot_mesh.csv
 
 Notes
 -----
-- Mesh-grid outputs are *predictions only* (no truth). This script therefore
-  compares OCELOT vs GFS on the same grid/points.
+- Mesh-grid outputs are *predictions only* (no truth). The analysis columns
+  provide a common mesh-space reference for both OCELOT and GFS forecast
+  verification.
 """
 
 from __future__ import annotations
@@ -24,6 +30,7 @@ import argparse
 import os
 import re
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
@@ -57,6 +64,76 @@ def _gfs_path(gfs_root: str, key: GfsKey) -> str:
     ymd = key.init_ymdh[:8]
     hh = key.init_ymdh[8:10]
     return os.path.join(gfs_root, ymd, f"gfs.{ymd}.t{hh}z.pgrb2.0p25.f{key.fhr:03d}")
+
+
+def _valid_time_ymdh(init_ymdh: str, fhr: int) -> str:
+    init_dt = datetime.strptime(init_ymdh, "%Y%m%d%H")
+    valid_dt = init_dt + timedelta(hours=fhr)
+    return valid_dt.strftime("%Y%m%d%H")
+
+
+def _analysis_path(gfs_root: str, valid_ymdh: str) -> str:
+    ymd = valid_ymdh[:8]
+    hh = valid_ymdh[8:10]
+    return os.path.join(gfs_root, ymd, f"gfs.{ymd}.t{hh}z.pgrb2.0p25.f000")
+
+
+def _cycle_floor(dt: datetime, cycle_hours: int = 6) -> datetime:
+    return dt.replace(hour=(dt.hour // cycle_hours) * cycle_hours, minute=0, second=0, microsecond=0)
+
+
+def _analysis_sources(gfs_root: str, valid_ymdh: str, mode: str) -> list[tuple[str, float]]:
+    """Return analysis f000 paths and weights for a valid time."""
+    if mode == "none":
+        return []
+
+    valid_dt = datetime.strptime(valid_ymdh, "%Y%m%d%H")
+    lower_dt = _cycle_floor(valid_dt)
+    upper_dt = lower_dt + timedelta(hours=6)
+
+    if mode == "exact":
+        if valid_dt != lower_dt:
+            print(f"[compare_mesh_to_gfs] valid time {valid_ymdh} is not on a 6h cycle; anl_* will be NaN")
+            return []
+        return [(_analysis_path(gfs_root, valid_ymdh), 1.0)]
+
+    if mode == "nearest":
+        lower_delta = abs((valid_dt - lower_dt).total_seconds())
+        upper_delta = abs((upper_dt - valid_dt).total_seconds())
+        nearest_dt = lower_dt if lower_delta <= upper_delta else upper_dt
+        return [(_analysis_path(gfs_root, nearest_dt.strftime("%Y%m%d%H")), 1.0)]
+
+    if mode == "time_interp":
+        if valid_dt == lower_dt:
+            return [(_analysis_path(gfs_root, valid_ymdh), 1.0)]
+        upper_weight = (valid_dt - lower_dt).total_seconds() / (upper_dt - lower_dt).total_seconds()
+        lower_weight = 1.0 - upper_weight
+        return [
+            (_analysis_path(gfs_root, lower_dt.strftime("%Y%m%d%H")), lower_weight),
+            (_analysis_path(gfs_root, upper_dt.strftime("%Y%m%d%H")), upper_weight),
+        ]
+
+    raise ValueError(f"Unsupported analysis_time_mode={mode!r}")
+
+
+def _validate_analysis_sources(sources: list[tuple[str, float]], valid_ymdh: str, mode: str) -> bool:
+    if not sources:
+        return False
+
+    missing = [path for path, _weight in sources if not os.path.exists(path)]
+    if missing:
+        print(
+            "[WARN] Missing GFS analysis file(s) for valid time "
+            f"{valid_ymdh}; anl_* will be NaN: {missing}"
+        )
+        return False
+
+    if len(sources) == 1:
+        print(f"[compare_mesh_to_gfs] Loading GFS analysis ({mode}): {sources[0][0]}")
+    else:
+        pieces = ", ".join(f"{path} weight={weight:.3f}" for path, weight in sources)
+        print(f"[compare_mesh_to_gfs] Time-interpolating GFS analysis for {valid_ymdh}: {pieces}")
+    return True
 
 
 def _open_cfgrib(path: str, *, type_of_level: str, level: int | None, short_name: str):
@@ -100,6 +177,50 @@ def _pick_var_name(ds, preferred: str) -> str:
     raise KeyError(f"Variable {preferred!r} not found; dataset has: {vars_}")
 
 
+def _interp_grib_field(
+    path: str,
+    *,
+    type_of_level: str,
+    level: int | None,
+    short_name: str,
+    preferred_var: str,
+    lat: np.ndarray,
+    lon360: np.ndarray,
+    method: str,
+    scale: float = 1.0,
+    offset: float = 0.0,
+) -> np.ndarray:
+    ds = _open_cfgrib(path, type_of_level=type_of_level, level=level, short_name=short_name)
+    try:
+        values = _interp_2d(ds, _pick_var_name(ds, preferred_var), lat, lon360, method=method)
+    finally:
+        close = getattr(ds, "close", None)
+        if close is not None:
+            close()
+    return values * scale + offset
+
+
+def _interp_mslp_hpa(path: str, lat: np.ndarray, lon360: np.ndarray, method: str) -> np.ndarray:
+    ds = _open_gfs_mean_sea_pressure(path)
+    try:
+        return _interp_2d(ds, _pick_var_name(ds, "prmsl"), lat, lon360, method=method) / 100.0
+    finally:
+        close = getattr(ds, "close", None)
+        if close is not None:
+            close()
+
+
+def _weighted_analysis(sources: list[tuple[str, float]], loader) -> np.ndarray | None:
+    if not sources:
+        return None
+
+    result = None
+    for path, weight in sources:
+        values = loader(path)
+        result = values * weight if result is None else result + values * weight
+    return result
+
+
 def _get_unique_pressure_hpa(df: pd.DataFrame) -> int:
     if "pressure_hPa" not in df.columns:
         raise ValueError("mesh CSV for radiosonde/aircraft must include pressure_hPa")
@@ -129,7 +250,12 @@ def _parse_mesh_filename(path: str) -> tuple[str, str, int]:
     return inst, init, fhr
 
 
-def add_gfs_to_surface_mesh(mesh_csv: str, gfs_root: str, method: str) -> pd.DataFrame:
+def add_gfs_to_surface_mesh(
+    mesh_csv: str,
+    gfs_root: str,
+    method: str,
+    analysis_time_mode: str = "exact",
+) -> pd.DataFrame:
     df = pd.read_csv(mesh_csv)
     if not {"lat", "lon"}.issubset(df.columns):
         raise ValueError("mesh CSV must include lat/lon")
@@ -167,17 +293,41 @@ def add_gfs_to_surface_mesh(mesh_csv: str, gfs_root: str, method: str) -> pd.Dat
     gfs_u = gfs_v = gfs_t2m_c = gfs_mslp_hpa = None
 
     if need_u:
-        ds = _open_cfgrib(gfs_path, type_of_level="heightAboveGround", level=10, short_name="10u")
-        gfs_u = _interp_2d(ds, _pick_var_name(ds, "u10"), lat, lon360, method=method)
+        gfs_u = _interp_grib_field(
+            gfs_path,
+            type_of_level="heightAboveGround",
+            level=10,
+            short_name="10u",
+            preferred_var="u10",
+            lat=lat,
+            lon360=lon360,
+            method=method,
+        )
     if need_v:
-        ds = _open_cfgrib(gfs_path, type_of_level="heightAboveGround", level=10, short_name="10v")
-        gfs_v = _interp_2d(ds, _pick_var_name(ds, "v10"), lat, lon360, method=method)
+        gfs_v = _interp_grib_field(
+            gfs_path,
+            type_of_level="heightAboveGround",
+            level=10,
+            short_name="10v",
+            preferred_var="v10",
+            lat=lat,
+            lon360=lon360,
+            method=method,
+        )
     if need_t:
-        ds = _open_cfgrib(gfs_path, type_of_level="heightAboveGround", level=2, short_name="2t")
-        gfs_t2m_c = _interp_2d(ds, _pick_var_name(ds, "t2m"), lat, lon360, method=method) - 273.15
+        gfs_t2m_c = _interp_grib_field(
+            gfs_path,
+            type_of_level="heightAboveGround",
+            level=2,
+            short_name="2t",
+            preferred_var="t2m",
+            lat=lat,
+            lon360=lon360,
+            method=method,
+            offset=-273.15,
+        )
     if need_sp:
-        ds = _open_gfs_mean_sea_pressure(gfs_path)
-        gfs_mslp_hpa = _interp_2d(ds, _pick_var_name(ds, "prmsl"), lat, lon360, method=method) / 100.0
+        gfs_mslp_hpa = _interp_mslp_hpa(gfs_path, lat, lon360, method=method)
 
     out = df.copy()
     if gfs_u is not None:
@@ -193,12 +343,87 @@ def add_gfs_to_surface_mesh(mesh_csv: str, gfs_root: str, method: str) -> pd.Dat
         out["gfs_mslp_hPa"] = gfs_mslp_hpa
         out["ocelot_minus_gfs_sp"] = out[sp_pred_col] - out["gfs_mslp_hPa"]
 
+    valid_ymdh = _valid_time_ymdh(init, fhr)
+    analysis_sources = _analysis_sources(gfs_root, valid_ymdh, analysis_time_mode)
+    have_analysis = _validate_analysis_sources(analysis_sources, valid_ymdh, analysis_time_mode)
+    if not have_analysis:
+        analysis_sources = []
+
+    anl_u = anl_v = anl_t2m_c = anl_mslp_hpa = None
+    if need_u:
+        anl_u = _weighted_analysis(
+            analysis_sources,
+            lambda path: _interp_grib_field(
+                path,
+                type_of_level="heightAboveGround",
+                level=10,
+                short_name="10u",
+                preferred_var="u10",
+                lat=lat,
+                lon360=lon360,
+                method=method,
+            ),
+        )
+        out["anl_u10"] = anl_u if anl_u is not None else np.nan
+        out["ocelot_minus_anl_u10"] = out["pred_wind_u"] - out["anl_u10"]
+        out["gfs_minus_anl_u10"] = out["gfs_u10"] - out["anl_u10"]
+    if need_v:
+        anl_v = _weighted_analysis(
+            analysis_sources,
+            lambda path: _interp_grib_field(
+                path,
+                type_of_level="heightAboveGround",
+                level=10,
+                short_name="10v",
+                preferred_var="v10",
+                lat=lat,
+                lon360=lon360,
+                method=method,
+            ),
+        )
+        out["anl_v10"] = anl_v if anl_v is not None else np.nan
+        out["ocelot_minus_anl_v10"] = out["pred_wind_v"] - out["anl_v10"]
+        out["gfs_minus_anl_v10"] = out["gfs_v10"] - out["anl_v10"]
+    if need_t:
+        anl_t2m_c = _weighted_analysis(
+            analysis_sources,
+            lambda path: _interp_grib_field(
+                path,
+                type_of_level="heightAboveGround",
+                level=2,
+                short_name="2t",
+                preferred_var="t2m",
+                lat=lat,
+                lon360=lon360,
+                method=method,
+                offset=-273.15,
+            ),
+        )
+        out["anl_t2m_C"] = anl_t2m_c if anl_t2m_c is not None else np.nan
+        out["ocelot_minus_anl_t2m"] = out["pred_airTemperature"] - out["anl_t2m_C"]
+        out["gfs_minus_anl_t2m"] = out["gfs_t2m_C"] - out["anl_t2m_C"]
+    if need_sp:
+        anl_mslp_hpa = _weighted_analysis(
+            analysis_sources,
+            lambda path: _interp_mslp_hpa(path, lat, lon360, method=method),
+        )
+        out["anl_mslp_hPa"] = anl_mslp_hpa if anl_mslp_hpa is not None else np.nan
+        out["ocelot_minus_anl_sp"] = out[sp_pred_col] - out["anl_mslp_hPa"]
+        out["gfs_minus_anl_sp"] = out["gfs_mslp_hPa"] - out["anl_mslp_hPa"]
+
     out["init_time"] = init
     out["fhr"] = fhr
+    out["valid_time"] = valid_ymdh
+    out["analysis_time_mode"] = analysis_time_mode
     return out
 
 
-def add_gfs_to_isobaric_mesh(mesh_csv: str, gfs_root: str, method: str) -> pd.DataFrame:
+def add_gfs_to_isobaric_mesh(
+    mesh_csv: str,
+    gfs_root: str,
+    method: str,
+    analysis_time_mode: str = "exact",
+) -> pd.DataFrame:
     """Add GFS (isobaric) fields to a radiosonde/aircraft mesh-grid prediction CSV."""
 
     df = pd.read_csv(mesh_csv)
@@ -236,14 +461,39 @@ def add_gfs_to_isobaric_mesh(mesh_csv: str, gfs_root: str, method: str) -> pd.Da
     gfs_u = gfs_v = gfs_t_c = None
 
     if need_u:
-        ds = _open_cfgrib(gfs_path, type_of_level="isobaricInhPa", level=level_hpa, short_name="u")
-        gfs_u = _interp_2d(ds, _pick_var_name(ds, "u"), lat, lon360, method=method)
+        gfs_u = _interp_grib_field(
+            gfs_path,
+            type_of_level="isobaricInhPa",
+            level=level_hpa,
+            short_name="u",
+            preferred_var="u",
+            lat=lat,
+            lon360=lon360,
+            method=method,
+        )
     if need_v:
-        ds = _open_cfgrib(gfs_path, type_of_level="isobaricInhPa", level=level_hpa, short_name="v")
-        gfs_v = _interp_2d(ds, _pick_var_name(ds, "v"), lat, lon360, method=method)
+        gfs_v = _interp_grib_field(
+            gfs_path,
+            type_of_level="isobaricInhPa",
+            level=level_hpa,
+            short_name="v",
+            preferred_var="v",
+            lat=lat,
+            lon360=lon360,
+            method=method,
+        )
     if need_t:
-        ds = _open_cfgrib(gfs_path, type_of_level="isobaricInhPa", level=level_hpa, short_name="t")
-        gfs_t_c = _interp_2d(ds, _pick_var_name(ds, "t"), lat, lon360, method=method) - 273.15
+        gfs_t_c = _interp_grib_field(
+            gfs_path,
+            type_of_level="isobaricInhPa",
+            level=level_hpa,
+            short_name="t",
+            preferred_var="t",
+            lat=lat,
+            lon360=lon360,
+            method=method,
+            offset=-273.15,
+        )
 
     out = df.copy()
     out["gfs_level_hPa"] = float(level_hpa)
@@ -257,29 +507,112 @@ def add_gfs_to_isobaric_mesh(mesh_csv: str, gfs_root: str, method: str) -> pd.Da
         out["gfs_airTemperature_C"] = gfs_t_c
         out["ocelot_minus_gfs_airTemperature"] = out["pred_airTemperature"] - out["gfs_airTemperature_C"]
 
+    valid_ymdh = _valid_time_ymdh(init, fhr)
+    analysis_sources = _analysis_sources(gfs_root, valid_ymdh, analysis_time_mode)
+    have_analysis = _validate_analysis_sources(analysis_sources, valid_ymdh, analysis_time_mode)
+    if not have_analysis:
+        analysis_sources = []
+
+    anl_u = anl_v = anl_t_c = None
+    if need_u:
+        anl_u = _weighted_analysis(
+            analysis_sources,
+            lambda path: _interp_grib_field(
+                path,
+                type_of_level="isobaricInhPa",
+                level=level_hpa,
+                short_name="u",
+                preferred_var="u",
+                lat=lat,
+                lon360=lon360,
+                method=method,
+            ),
+        )
+        out["anl_u"] = anl_u if anl_u is not None else np.nan
+        out["ocelot_minus_anl_u"] = out["pred_wind_u"] - out["anl_u"]
+        out["gfs_minus_anl_u"] = out["gfs_u"] - out["anl_u"]
+    if need_v:
+        anl_v = _weighted_analysis(
+            analysis_sources,
+            lambda path: _interp_grib_field(
+                path,
+                type_of_level="isobaricInhPa",
+                level=level_hpa,
+                short_name="v",
+                preferred_var="v",
+                lat=lat,
+                lon360=lon360,
+                method=method,
+            ),
+        )
+        out["anl_v"] = anl_v if anl_v is not None else np.nan
+        out["ocelot_minus_anl_v"] = out["pred_wind_v"] - out["anl_v"]
+        out["gfs_minus_anl_v"] = out["gfs_v"] - out["anl_v"]
+    if need_t:
+        anl_t_c = _weighted_analysis(
+            analysis_sources,
+            lambda path: _interp_grib_field(
+                path,
+                type_of_level="isobaricInhPa",
+                level=level_hpa,
+                short_name="t",
+                preferred_var="t",
+                lat=lat,
+                lon360=lon360,
+                method=method,
+                offset=-273.15,
+            ),
+        )
+        out["anl_airTemperature_C"] = anl_t_c if anl_t_c is not None else np.nan
+        out["ocelot_minus_anl_airTemperature"] = out["pred_airTemperature"] - out["anl_airTemperature_C"]
+        out["gfs_minus_anl_airTemperature"] = out["gfs_airTemperature_C"] - out["anl_airTemperature_C"]
+
     out["init_time"] = init
     out["fhr"] = fhr
     out["instrument"] = inst
+    out["valid_time"] = valid_ymdh
+    out["analysis_time_mode"] = analysis_time_mode
     return out
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser()
+    ap = argparse.ArgumentParser(
+        description="Interpolate GFS forecast and analysis onto OCELOT mesh-grid prediction points."
+    )
     ap.add_argument("--mesh_csv", required=True, help="Mesh-grid prediction CSV, e.g. surface_obs_init_YYYYMMDDHH_f003.csv")
     ap.add_argument("--gfs_root", required=True)
     ap.add_argument("--out_csv", required=True)
     ap.add_argument("--interp", default="nearest", choices=["nearest", "linear"])
+    ap.add_argument(
+        "--analysis_time_mode",
+        default="exact",
+        choices=["time_interp", "exact", "nearest", "none"],
+        help=(
+            "How to sample f000 GFS analysis for anl_* columns. "
+            "Default exact adds analysis only at native 00/06/12/18Z valid times."
+        ),
+    )
     args = ap.parse_args()
 
     inst, _init, _fhr = _parse_mesh_filename(args.mesh_csv)
     if inst in {"surface_obs", "surface"}:
-        out = add_gfs_to_surface_mesh(args.mesh_csv, gfs_root=args.gfs_root, method=args.interp)
+        out = add_gfs_to_surface_mesh(
+            args.mesh_csv,
+            gfs_root=args.gfs_root,
+            method=args.interp,
+            analysis_time_mode=args.analysis_time_mode,
+        )
     elif inst in {"radiosonde", "aircraft"}:
-        out = add_gfs_to_isobaric_mesh(args.mesh_csv, gfs_root=args.gfs_root, method=args.interp)
+        out = add_gfs_to_isobaric_mesh(
+            args.mesh_csv,
+            gfs_root=args.gfs_root,
+            method=args.interp,
+            analysis_time_mode=args.analysis_time_mode,
+        )
     else:
         raise SystemExit(
             f"Unsupported mesh instrument={inst!r} in {os.path.basename(args.mesh_csv)}. "
-            "Supported: surface_obs, radiosonde."
+            "Supported: surface_obs, radiosonde, aircraft."
         )
 
     os.makedirs(os.path.dirname(args.out_csv) or ".", exist_ok=True)

--- a/gnn_model/evaluation/scripts/evaluations.py
+++ b/gnn_model/evaluation/scripts/evaluations.py
@@ -283,10 +283,16 @@ def compute_pointwise_metrics_from_val_csv(
             except Exception:
                 pass
 
-        # Identify base variables from pred_* columns.
-        pred_cols = [c for c in df.columns if c.startswith("pred_")]
-        for pred_col in pred_cols:
-            base_var = pred_col[len("pred_"):]
+        # Identify forecast-like variables from pred_* and optional persist_* columns.
+        forecast_cols = [
+            ("ocelot", c, c[len("pred_"):])
+            for c in df.columns if c.startswith("pred_")
+        ]
+        forecast_cols.extend(
+            ("persistence", c, c[len("persist_"):])
+            for c in df.columns if c.startswith("persist_")
+        )
+        for baseline, pred_col, base_var in forecast_cols:
             true_col = f"true_{base_var}"
             if true_col not in df.columns:
                 continue
@@ -330,13 +336,14 @@ def compute_pointwise_metrics_from_val_csv(
 
             # Always include variable
             gcols["variable"] = np.array([base_var] * int(valid.sum()), dtype=object)
+            gcols["baseline"] = np.array([baseline] * int(valid.sum()), dtype=object)
 
             gdf = pd.DataFrame(gcols)
             gdf["abs_err"] = abs_err
             gdf["sq_err"] = sq_err
             gdf["err"] = err
 
-            gb = gdf.groupby([k for k in groupby_keys if k != "variable"] + ["variable"], dropna=False)
+            gb = gdf.groupby([k for k in groupby_keys if k not in ("variable", "baseline")] + ["variable", "baseline"], dropna=False)
             agg = gb.agg(
                 n=("err", "size"),
                 sum_abs=("abs_err", "sum"),
@@ -352,7 +359,9 @@ def compute_pointwise_metrics_from_val_csv(
 
     # Combine across all files/batches by summing sufficient statistics.
     out_df = pd.concat(rows_out, ignore_index=True)
-    gb_keys = [k for k in groupby_keys if k != "variable" and k in out_df.columns] + ["variable"]
+    gb_keys = [k for k in groupby_keys if k not in ("variable", "baseline") and k in out_df.columns] + ["variable"]
+    if "baseline" in out_df.columns:
+        gb_keys.append("baseline")
     out_df = out_df.groupby(gb_keys, dropna=False, as_index=False).agg(
         n=("n", "sum"),
         sum_abs=("sum_abs", "sum"),
@@ -368,8 +377,11 @@ def compute_pointwise_metrics_from_val_csv(
     out_df.drop(columns=["sum_abs", "sum_sq", "sum_err"], inplace=True)
 
     # Stable column ordering
-    base_cols = [k for k in groupby_keys if k in out_df.columns and k != "variable"]
-    cols = base_cols + ["variable", "n", "rmse", "mae", "bias"]
+    base_cols = [
+        k for k in groupby_keys
+        if k in out_df.columns and k not in ("variable", "baseline")
+    ]
+    cols = base_cols + ["variable", "baseline", "n", "rmse", "mae", "bias"]
     cols = [c for c in cols if c in out_df.columns] + [c for c in out_df.columns if c not in cols]
     out_df = out_df[cols]
 

--- a/gnn_model/evaluation/scripts/make_2025_init.py
+++ b/gnn_model/evaluation/scripts/make_2025_init.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+"""Build initialization lists from available GFS cycles.
+
+Supported sampling modes:
+
+paired_cycles:
+    Select N dates and emit all requested cycles for each date.
+    Example: --num-dates 15 --cycles 00,12 -> 30 init times.
+
+balanced_distinct:
+    Select NUM_INITS distinct date-cycle pairs, balanced across cycles.
+    Example: --num-inits 30 --cycles 00,12 -> 15 00Z + 15 12Z,
+    preferably on distinct dates.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _has_required_files(root: Path, ymd: str, hh: str, required_fhrs: list[int]) -> bool:
+    for fhr in required_fhrs:
+        p = root / ymd / f"gfs.{ymd}.t{hh}z.pgrb2.0p25.f{fhr:03d}"
+        if not p.exists():
+            return False
+    return True
+
+
+def _evenly_select(items: list[str], n: int) -> list[str]:
+    if n <= 0:
+        return []
+    if len(items) < n:
+        raise ValueError(f"Need {n} items, only found {len(items)}")
+    if n == 1:
+        return [items[0]]
+
+    idx = [round(i * (len(items) - 1) / (n - 1)) for i in range(n)]
+    out = [items[i] for i in idx]
+
+    # Guard against duplicate indices from rounding.
+    if len(set(out)) != len(out):
+        out = []
+        for item in items:
+            out.append(item)
+            if len(out) == n:
+                break
+
+    return out
+
+
+def _parse_cycles(cycles_str: str) -> list[str]:
+    return [c.strip().zfill(2) for c in cycles_str.split(",") if c.strip()]
+
+
+def _parse_fhrs(fhrs_str: str) -> list[int]:
+    return [int(x) for x in fhrs_str.split(",") if x.strip()]
+
+
+def _available_dates(root: Path, year: int, start_date: str, end_date: str) -> list[str]:
+    return sorted(
+        p.name
+        for p in root.iterdir()
+        if (
+            p.is_dir()
+            and p.name.isdigit()
+            and p.name.startswith(str(year))
+            and start_date <= p.name <= end_date
+        )
+    )
+
+
+def _make_paired_cycles(
+    root: Path,
+    dates: list[str],
+    cycles: list[str],
+    required_fhrs: list[int],
+    num_dates: int,
+) -> list[str]:
+    usable_dates = [
+        ymd
+        for ymd in dates
+        if all(_has_required_files(root, ymd, hh, required_fhrs) for hh in cycles)
+    ]
+
+    selected_dates = _evenly_select(usable_dates, num_dates)
+    return [f"{ymd}{hh}" for ymd in selected_dates for hh in cycles]
+
+
+def _make_balanced_distinct(
+    root: Path,
+    dates: list[str],
+    cycles: list[str],
+    required_fhrs: list[int],
+    num_inits: int,
+) -> list[str]:
+    if num_inits <= 0:
+        return []
+
+    ncycles = len(cycles)
+    base = num_inits // ncycles
+    remainder = num_inits % ncycles
+
+    per_cycle_counts = {
+        hh: base + (1 if i < remainder else 0)
+        for i, hh in enumerate(cycles)
+    }
+
+    selected_inits: list[str] = []
+    used_dates: set[str] = set()
+
+    for hh in cycles:
+        valid_dates_for_cycle = [
+            ymd
+            for ymd in dates
+            if _has_required_files(root, ymd, hh, required_fhrs)
+        ]
+
+        # Prefer dates not already used by another cycle, so 00Z and 12Z
+        # come from different calendar days when possible.
+        unused_dates = [ymd for ymd in valid_dates_for_cycle if ymd not in used_dates]
+
+        need = per_cycle_counts[hh]
+        if len(unused_dates) >= need:
+            chosen_dates = _evenly_select(unused_dates, need)
+        else:
+            # Fallback: allow same-date reuse only if necessary.
+            chosen_dates = _evenly_select(valid_dates_for_cycle, need)
+
+        used_dates.update(chosen_dates)
+        selected_inits.extend(f"{ymd}{hh}" for ymd in chosen_dates)
+
+    return sorted(selected_inits)
+
+
+def _make_all_inits(
+    root: Path,
+    dates: list[str],
+    cycles: list[str],
+    required_fhrs: list[int],
+) -> list[str]:
+    return [
+        f"{ymd}{hh}"
+        for ymd in dates
+        for hh in cycles
+        if _has_required_files(root, ymd, hh, required_fhrs)
+    ]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--gfs-root",
+        default="/scratch3/NCEPDEV/da/Mu-Chieh.Ko/JEDI-nudging/gfs-rt25",
+    )
+    ap.add_argument("--year", type=int, default=2025)
+    ap.add_argument(
+        "--start-date",
+        default="20250108",
+        help="Earliest initialization date to consider, YYYYMMDD.",
+    )
+    ap.add_argument(
+        "--end-date",
+        default="20251231",
+        help="Latest initialization date to consider, YYYYMMDD.",
+    )
+
+    # Backward-compatible sampled options.
+    ap.add_argument("--num-dates", type=int, default=None)
+    ap.add_argument("--num-inits", type=int, default=None)
+    ap.add_argument(
+        "--all-inits",
+        action="store_true",
+        help="Emit every available date-cycle pair in the requested date window.",
+    )
+
+    ap.add_argument("--cycles", default="00,12")
+    ap.add_argument("--required-fhrs", default="0,1,2,3,4,5,6,7,8,9,10,11,12")
+    ap.add_argument(
+        "--sample-mode",
+        choices=["paired_cycles", "balanced_distinct"],
+        default="paired_cycles",
+    )
+    ap.add_argument(
+        "--format",
+        choices=["plain", "bash"],
+        default="plain",
+        help="plain: one init per line; bash: INIT_TIMES=(...)",
+    )
+
+    args = ap.parse_args()
+
+    root = Path(args.gfs_root)
+    cycles = _parse_cycles(args.cycles)
+    required_fhrs = _parse_fhrs(args.required_fhrs)
+
+    dates = _available_dates(
+        root=root,
+        year=args.year,
+        start_date=args.start_date,
+        end_date=args.end_date,
+    )
+
+    if args.all_inits:
+        inits = _make_all_inits(
+            root=root,
+            dates=dates,
+            cycles=cycles,
+            required_fhrs=required_fhrs,
+        )
+
+    elif args.sample_mode == "paired_cycles":
+        if args.num_dates is not None:
+            num_dates = args.num_dates
+        elif args.num_inits is not None:
+            if args.num_inits % len(cycles) != 0:
+                raise ValueError(
+                    f"paired_cycles requires num_inits divisible by number of cycles. "
+                    f"Got num_inits={args.num_inits}, cycles={cycles}"
+                )
+            num_dates = args.num_inits // len(cycles)
+        else:
+            num_dates = 60
+
+        inits = _make_paired_cycles(
+            root=root,
+            dates=dates,
+            cycles=cycles,
+            required_fhrs=required_fhrs,
+            num_dates=num_dates,
+        )
+
+    elif args.sample_mode == "balanced_distinct":
+        if args.num_inits is None:
+            raise ValueError("balanced_distinct requires --num-inits")
+
+        inits = _make_balanced_distinct(
+            root=root,
+            dates=dates,
+            cycles=cycles,
+            required_fhrs=required_fhrs,
+            num_inits=args.num_inits,
+        )
+
+    else:
+        raise ValueError(f"Unknown sample mode: {args.sample_mode}")
+
+    if args.format == "bash":
+        print("INIT_TIMES=(")
+        for init in inits:
+            print(f"  {init}")
+        print(")")
+    else:
+        print("\n".join(inits))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gnn_model/evaluation/scripts/plot_mesh_vs_gfs_maps.py
+++ b/gnn_model/evaluation/scripts/plot_mesh_vs_gfs_maps.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Plot mesh-grid OCELOT vs GFS comparisons.
+"""Plot mesh-grid OCELOT vs GFS comparisons, with analysis when available.
 
 Author: Azadeh Gholoubi
 
@@ -7,9 +7,14 @@ Input CSV is produced by compare_mesh_to_gfs.py and should contain:
 - lat, lon
 - pred_* columns
 - gfs_* columns
+- optional anl_* columns
 
-Outputs a 3-panel scatter map on the *same* mesh points:
+Outputs a 3-panel scatter map when analysis is unavailable:
   [OCELOT] [GFS] [OCELOT - GFS]
+
+Outputs a 6-panel scatter map when analysis is available:
+  [OCELOT forecast] [GFS forecast] [GFS analysis]
+  [OCELOT - GFS]   [OCELOT - analysis] [GFS - analysis]
 
 If --gfs_root is provided, also writes a diagnostic 2-panel plot to visualize
 the *native* GRIB GFS field (0.25°) alongside the GFS values interpolated to
@@ -159,6 +164,15 @@ def _add_land(ax):
 
     mode = os.environ.get("OCELOT_CARTOPY_FEATURES", "auto").strip().lower()
     if mode in {"0", "false", "no", "off"}:
+        return
+    if mode == "auto" and not _cartopy_natural_earth_cached():
+        if not _CARTOPY_FEATURES_WARNED:
+            _CARTOPY_FEATURES_WARNED = True
+            print(
+                "[WARN] Cartopy NaturalEarth coastlines/borders are not cached; "
+                "skipping map features to avoid network download on compute nodes. "
+                "Set OCELOT_CARTOPY_FEATURES=1 to force."
+            )
         return
 
     try:
@@ -386,6 +400,100 @@ def plot_tripanel(lon, lat, pred, gfs, title, out_png, units: str | None, point_
     print(f"Wrote: {out_png}")
 
 
+def plot_sixpanel(
+    lon: np.ndarray,
+    lat: np.ndarray,
+    pred: np.ndarray,
+    gfs: np.ndarray,
+    anl: np.ndarray,
+    title: str,
+    out_png: str,
+    units: str | None,
+    point_size: int,
+):
+    import cartopy.crs as ccrs
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt  # noqa: E402
+    from matplotlib.colors import TwoSlopeNorm  # noqa: E402
+
+    diff_og = pred - gfs
+    diff_oa = pred - anl
+    diff_ga = gfs - anl
+
+    m_og = _metrics(pred, gfs)
+    m_oa = _metrics(pred, anl)
+    m_ga = _metrics(gfs, anl)
+
+    vmin, vmax = _robust_limits(np.concatenate([pred, gfs, anl]), 1.0, 99.0)
+    all_diffs = np.concatenate([
+        diff_og[np.isfinite(diff_og)],
+        diff_oa[np.isfinite(diff_oa)],
+        diff_ga[np.isfinite(diff_ga)],
+    ])
+    dmin, dmax = _robust_sym(all_diffs, 99.0)
+    diff_norm = TwoSlopeNorm(vmin=dmin, vcenter=0.0, vmax=dmax)
+
+    fig, axes = plt.subplots(
+        2,
+        3,
+        figsize=(20, 10),
+        subplot_kw={"projection": ccrs.PlateCarree()},
+        sharex=True,
+        sharey=True,
+    )
+
+    val_label = f"Value{f' ({units})' if units else ''}"
+    diff_label = f"Delta{f' ({units})' if units else ''}"
+
+    row0 = [
+        ("OCELOT forecast", pred),
+        ("GFS forecast", gfs),
+        ("GFS analysis", anl),
+    ]
+    for ax, (ttl, field) in zip(axes[0], row0):
+        ax.set_title(ttl, fontsize=13)
+        sc = ax.scatter(lon, lat, c=field, s=point_size, cmap="turbo", vmin=vmin, vmax=vmax, transform=ccrs.PlateCarree())
+        fig.colorbar(sc, ax=ax, orientation="vertical", pad=0.02).set_label(val_label)
+        _add_land(ax)
+        ax.set_global()
+
+    row1 = [
+        (f"OCELOT - GFS  (RMSE={m_og['rmse']:.3g}  Bias={m_og['bias']:.3g})", diff_og),
+        (f"OCELOT - analysis  (RMSE={m_oa['rmse']:.3g}  Bias={m_oa['bias']:.3g})", diff_oa),
+        (f"GFS - analysis  (RMSE={m_ga['rmse']:.3g}  Bias={m_ga['bias']:.3g})", diff_ga),
+    ]
+    for ax, (ttl, field) in zip(axes[1], row1):
+        ax.set_title(ttl, fontsize=11)
+        sc = ax.scatter(lon, lat, c=field, s=point_size, cmap="bwr", norm=diff_norm, transform=ccrs.PlateCarree())
+        fig.colorbar(sc, ax=ax, orientation="vertical", pad=0.02).set_label(diff_label)
+        _add_land(ax)
+        ax.set_global()
+
+    fig.suptitle(f"{title}  |  N={m_og['n']}", fontsize=14, y=1.01)
+    plt.tight_layout()
+    plt.savefig(out_png, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote: {out_png}")
+
+
+def _col_map(var: str, df: pd.DataFrame) -> tuple[str | None, str, str, str | None]:
+    if var == "u10":
+        return "pred_wind_u", "gfs_u10", "anl_u10", "m/s"
+    if var == "v10":
+        return "pred_wind_v", "gfs_v10", "anl_v10", "m/s"
+    if var == "t2m":
+        return "pred_airTemperature", "gfs_t2m_C", "anl_t2m_C", "deg C"
+    if var == "sp":
+        return _surface_pressure_pred_col(df), "gfs_mslp_hPa", "anl_mslp_hPa", "hPa"
+    if var == "u":
+        return "pred_wind_u", "gfs_u", "anl_u", "m/s"
+    if var == "v":
+        return "pred_wind_v", "gfs_v", "anl_v", "m/s"
+    return "pred_airTemperature", "gfs_airTemperature_C", "anl_airTemperature_C", "deg C"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument(
@@ -415,21 +523,7 @@ def main() -> int:
     lon = pd.to_numeric(df["lon"], errors="coerce").to_numpy(dtype=np.float64)
     lat = pd.to_numeric(df["lat"], errors="coerce").to_numpy(dtype=np.float64)
 
-    if args.var == "u10":
-        pred_col, gfs_col, units = "pred_wind_u", "gfs_u10", "m/s"
-    elif args.var == "v10":
-        pred_col, gfs_col, units = "pred_wind_v", "gfs_v10", "m/s"
-    elif args.var == "t2m":
-        pred_col, gfs_col, units = "pred_airTemperature", "gfs_t2m_C", "°C"
-    elif args.var == "sp":
-        pred_col = _surface_pressure_pred_col(df)
-        gfs_col, units = "gfs_mslp_hPa", "hPa"
-    elif args.var == "u":
-        pred_col, gfs_col, units = "pred_wind_u", "gfs_u", "m/s"
-    elif args.var == "v":
-        pred_col, gfs_col, units = "pred_wind_v", "gfs_v", "m/s"
-    else:  # temp
-        pred_col, gfs_col, units = "pred_airTemperature", "gfs_airTemperature_C", "°C"
+    pred_col, gfs_col, anl_col, units = _col_map(args.var, df)
 
     level_tag = ""
     level_hpa = None
@@ -449,24 +543,36 @@ def main() -> int:
 
     pred = pd.to_numeric(df[pred_col], errors="coerce").to_numpy(dtype=np.float64)
     gfs = pd.to_numeric(df[gfs_col], errors="coerce").to_numpy(dtype=np.float64)
-    valid = np.isfinite(lon) & np.isfinite(lat) & np.isfinite(pred) & np.isfinite(gfs)
-    lon, lat, pred, gfs = lon[valid], lat[valid], pred[valid], gfs[valid]
+    has_analysis = anl_col in df.columns and pd.to_numeric(df[anl_col], errors="coerce").notna().any()
+    anl = pd.to_numeric(df[anl_col], errors="coerce").to_numpy(dtype=np.float64) if has_analysis else None
 
     lvl = f" • {level_tag}" if level_tag else ""
-    title = f"mesh-grid {args.var}{lvl} • OCELOT_on_mesh vs GFS_on_mesh"
-    out_png = os.path.join(args.plot_dir, f"mesh_OCELOT_on_mesh_vs_GFS_on_mesh_{args.var}{('_'+level_tag) if level_tag else ''}.png")
-    plot_tripanel(lon, lat, pred, gfs, title, out_png, units=units, point_size=int(args.point_size))
+    level_suffix = f"{'_' + level_tag if level_tag else ''}"
+    instrument = os.path.basename(args.csv).split("_init_")[0]
+
+    if has_analysis:
+        valid = np.isfinite(lon) & np.isfinite(lat) & np.isfinite(pred) & np.isfinite(gfs) & np.isfinite(anl)
+        _lon, _lat, _pred, _gfs, _anl = lon[valid], lat[valid], pred[valid], gfs[valid], anl[valid]
+        title = f"mesh-grid {args.var}{lvl} • vs GFS forecast + analysis"
+        out_png = os.path.join(args.plot_dir, f"{instrument}_mesh_6panel_{args.var}{level_suffix}.png")
+        plot_sixpanel(_lon, _lat, _pred, _gfs, _anl, title, out_png, units=units, point_size=int(args.point_size))
+    else:
+        valid = np.isfinite(lon) & np.isfinite(lat) & np.isfinite(pred) & np.isfinite(gfs)
+        _lon, _lat, _pred, _gfs = lon[valid], lat[valid], pred[valid], gfs[valid]
+        title = f"mesh-grid {args.var}{lvl} • OCELOT_on_mesh vs GFS_on_mesh"
+        out_png = os.path.join(args.plot_dir, f"mesh_OCELOT_on_mesh_vs_GFS_on_mesh_{args.var}{level_suffix}.png")
+        plot_tripanel(_lon, _lat, _pred, _gfs, title, out_png, units=units, point_size=int(args.point_size))
 
     if args.gfs_root:
         init_ymdh, fhr = _infer_init_fhr(df, csv_path=str(args.csv))
         out_png2 = os.path.join(
             args.plot_dir,
-            f"mesh_GFS_native_vs_GFS_on_mesh_{args.var}{('_'+level_tag) if level_tag else ''}_init_{init_ymdh}_f{int(fhr):03d}.png",
+            f"mesh_GFS_native_vs_GFS_on_mesh_{args.var}{level_suffix}_init_{init_ymdh}_f{int(fhr):03d}.png",
         )
         plot_gfs_native_vs_mesh_interp(
-            lon=lon,
-            lat=lat,
-            gfs_on_mesh=gfs,
+            lon=_lon,
+            lat=_lat,
+            gfs_on_mesh=_gfs,
             var=str(args.var),
             units=units,
             init_ymdh=str(init_ymdh),

--- a/gnn_model/evaluation/scripts/run_pred_eval_gfs.sh
+++ b/gnn_model/evaluation/scripts/run_pred_eval_gfs.sh
@@ -16,15 +16,19 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [[ -n "${SLURM_SUBMIT_DIR:-}" && -d "${SLURM_SUBMIT_DIR}" ]]; then
+SOURCE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -n "${GNN_MODEL_DIR:-}" && -f "${GNN_MODEL_DIR}/predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${GNN_MODEL_DIR}" && pwd)"
+elif [[ -n "${SLURM_SUBMIT_DIR:-}" && -f "${SLURM_SUBMIT_DIR}/predict_gnn.py" ]]; then
   GNN_MODEL_DIR="$(cd "${SLURM_SUBMIT_DIR}" && pwd)"
+elif [[ -f "${SOURCE_SCRIPT_DIR}/../../predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${SOURCE_SCRIPT_DIR}/../.." && pwd)"
 else
-  GNN_MODEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+  GNN_MODEL_DIR="/scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/main_PR/ocelot/gnn_model"
 fi
 OCELOT_DIR="$(cd "${GNN_MODEL_DIR}/.." && pwd)"
 
-cd "${SLURM_SUBMIT_DIR:-${GNN_MODEL_DIR}}"
+cd "${GNN_MODEL_DIR}"
 
 # =====================
 # User-config parameters
@@ -88,6 +92,24 @@ GFS_ROOT=${GFS_ROOT:-/scratch3/NCEPDEV/da/Mu-Chieh.Ko/JEDI-nudging/gfs-rt25}
 # - nominal: use init + fhr (bucket end)
 # - obs_interp: time-interpolate GFS to each row's observation time (recommended)
 GFS_TIME_MODE=${GFS_TIME_MODE:-obs_interp}
+GFS_FHR_STEP=${GFS_FHR_STEP:-3}
+ANALYSIS_TIME_MODE=${ANALYSIS_TIME_MODE:-exact}
+
+# Workflow switches. Set CSV_ONLY=1 for post-processing jobs that should not
+# spend time making per-init plots.
+CSV_ONLY=${CSV_ONLY:-0}
+RUN_PREDICTION=${RUN_PREDICTION:-1}
+RUN_TRUTH_PLOTS=${RUN_TRUTH_PLOTS:-1}
+RUN_METRICS=${RUN_METRICS:-1}
+RUN_OBS_GFS_CSV=${RUN_OBS_GFS_CSV:-1}
+RUN_GFS_PLOTS=${RUN_GFS_PLOTS:-1}
+RUN_MESH_GFS_CSV=${RUN_MESH_GFS_CSV:-1}
+RUN_MESH_GFS_PLOTS=${RUN_MESH_GFS_PLOTS:-1}
+if [ "${CSV_ONLY}" = "1" ]; then
+  RUN_TRUTH_PLOTS=0
+  RUN_GFS_PLOTS=0
+  RUN_MESH_GFS_PLOTS=0
+fi
 
 # Outputs
 OUT_ROOT=${OUT_ROOT:-"predictions/${EXP_NAME}"}
@@ -116,7 +138,17 @@ echo "CKPT=${CKPT}"
 echo "OUT_ROOT=${OUT_ROOT}"
 echo "GFS_ROOT=${GFS_ROOT}"
 echo "GFS_TIME_MODE=${GFS_TIME_MODE}"
+echo "GFS_FHR_STEP=${GFS_FHR_STEP}"
+echo "ANALYSIS_TIME_MODE=${ANALYSIS_TIME_MODE}"
 echo "RADIOSONDE_LEVELS=${RADIOSONDE_LEVELS}"
+echo "CSV_ONLY=${CSV_ONLY}"
+echo "RUN_PREDICTION=${RUN_PREDICTION}"
+echo "RUN_TRUTH_PLOTS=${RUN_TRUTH_PLOTS}"
+echo "RUN_METRICS=${RUN_METRICS}"
+echo "RUN_OBS_GFS_CSV=${RUN_OBS_GFS_CSV}"
+echo "RUN_GFS_PLOTS=${RUN_GFS_PLOTS}"
+echo "RUN_MESH_GFS_CSV=${RUN_MESH_GFS_CSV}"
+echo "RUN_MESH_GFS_PLOTS=${RUN_MESH_GFS_PLOTS}"
 
 if [ "${INSTRUMENT}" = "radiosonde" ] && [ -z "${OBS_SPACE_PRESSURE_LEVEL_IDX}" ] && [ -n "${MESH_PRESSURE_LEVEL_IDX:-}" ]; then
   OBS_SPACE_PRESSURE_LEVEL_IDX="${MESH_PRESSURE_LEVEL_IDX}"
@@ -138,7 +170,13 @@ if [[ ! -x "${MM}" ]]; then
   exit 2
 fi
 
-PY=("${MM}" run -n "${OCELOT_ENV_NAME}" python)
+ENV_PY="${MAMBA_ROOT_PREFIX}/envs/${OCELOT_ENV_NAME}/bin/python"
+if [[ -x "${ENV_PY}" && "${USE_MICROMAMBA_RUN:-0}" != "1" ]]; then
+  PY=("${ENV_PY}")
+else
+  PY=("${MM}" run -n "${OCELOT_ENV_NAME}" python)
+fi
+echo "PY=${PY[*]}"
 
 # Ensure we run the code from THIS checkout (not NNJA mirror)
 export PYTHONPATH="${GNN_MODEL_DIR}:${OCELOT_DIR}:${PYTHONPATH:-}"
@@ -148,39 +186,53 @@ export PYTHONPATH="${GNN_MODEL_DIR}:${OCELOT_DIR}:${PYTHONPATH:-}"
 INIT_DATE="${INIT_TIME:0:8}"
 START_DATE=$(date -u -d "${INIT_DATE} -1 day" +%Y-%m-%d)
 END_DATE=$(date -u -d "${INIT_DATE} +1 day" +%Y-%m-%d)
+export PREDICT_INIT_TIME_FILTER=${PREDICT_INIT_TIME_FILTER:-${INIT_TIME}}
 
 echo "START_DATE=${START_DATE} END_DATE=${END_DATE}"
+echo "PREDICT_INIT_TIME_FILTER=${PREDICT_INIT_TIME_FILTER}"
 
 mkdir -p "${OUT_ROOT}" "${PLOT_TRUTH_DIR}" "${PLOT_GFS_DIR}" "${PLOT_MESH_GFS_DIR}"
 
-echo "==== 1) Prediction (obs-space, with truth) ===="
-srun --export=ALL --kill-on-bad-exit=1 --cpu-bind=cores \
-  "${MM}" run -n "${OCELOT_ENV_NAME}" python predict_gnn.py \
-    --checkpoint "${CKPT}" \
-    --start_date "${START_DATE}" \
-    --end_date "${END_DATE}" \
-    --output_dir "${OUT_ROOT}" \
-    --eval-mode \
-    --devices 1 \
-    --num_nodes 1 \
-    --batch_size 1
+if [ "${RUN_PREDICTION}" = "1" ]; then
+  echo "==== 1) Prediction (obs-space, with truth) ===="
+  srun --export=ALL --kill-on-bad-exit=1 --cpu-bind=cores \
+    "${PY[@]}" predict_gnn.py \
+      --checkpoint "${CKPT}" \
+      --start_date "${START_DATE}" \
+      --end_date "${END_DATE}" \
+      --output_dir "${OUT_ROOT}" \
+      --eval-mode \
+      --devices 1 \
+      --num_nodes 1 \
+      --batch_size 1
+else
+  echo "==== 1) Prediction skipped (RUN_PREDICTION=${RUN_PREDICTION}) ===="
+fi
 
-echo "==== 2) OCELOT vs Truth plots (per lead hour) ===="
-"${PY[@]}" "${EVAL_SCRIPT}" --mode plots --has_ground_truth \
-  --data_dir "${OBS_DIR}" \
-  --plot_dir "${PLOT_TRUTH_DIR}" \
-  --init_time "${INIT_TIME}" \
-  --fhr "${EVAL_FHR_DEFAULT}" \
-  --plot_all_fhrs \
-  --plot_horizon_12h \
-  ${EVAL_EXTRA_ARGS}
+if [ "${RUN_TRUTH_PLOTS}" = "1" ]; then
+  echo "==== 2) OCELOT vs Truth plots (per lead hour) ===="
+  "${PY[@]}" "${EVAL_SCRIPT}" --mode plots --has_ground_truth \
+    --data_dir "${OBS_DIR}" \
+    --plot_dir "${PLOT_TRUTH_DIR}" \
+    --init_time "${INIT_TIME}" \
+    --fhr "${EVAL_FHR_DEFAULT}" \
+    --plot_all_fhrs \
+    --plot_horizon_12h \
+    ${EVAL_EXTRA_ARGS}
+else
+  echo "==== 2) OCELOT vs Truth plots skipped (RUN_TRUTH_PLOTS=${RUN_TRUTH_PLOTS}) ===="
+fi
 
-echo "==== 2b) Pointwise metrics (pred vs truth) ===="
-"${PY[@]}" "${EVAL_SCRIPT}" --mode metrics \
-  --data_dir "${OBS_DIR}" \
-  --metrics_pattern "pred_*init_${INIT_TIME}.csv" \
-  --metrics_out "${OUT_ROOT}/metrics_pointwise_init_${INIT_TIME}.csv" \
-  --metrics_groupby instrument,lead_hours_nominal
+if [ "${RUN_METRICS}" = "1" ]; then
+  echo "==== 2b) Pointwise metrics (pred vs truth) ===="
+  "${PY[@]}" "${EVAL_SCRIPT}" --mode metrics \
+    --data_dir "${OBS_DIR}" \
+    --metrics_pattern "pred_*init_${INIT_TIME}.csv" \
+    --metrics_out "${OUT_ROOT}/metrics_pointwise_init_${INIT_TIME}.csv" \
+    --metrics_groupby instrument,lead_hours_nominal
+else
+  echo "==== 2b) Pointwise metrics skipped (RUN_METRICS=${RUN_METRICS}) ===="
+fi
 
 echo "==== 3) Build *_vs_gfs.csv (obs-space OCELOT vs GFS) ===="
 OCELOT_CSV="${OBS_DIR}/pred_${INSTRUMENT}_target_init_${INIT_TIME}.csv"
@@ -201,6 +253,7 @@ COMPARE_TO_GFS_ARGS=(
   --init_mode from_csv
   --interp nearest
   --gfs_time_mode "${GFS_TIME_MODE}"
+  --fhr_step "${GFS_FHR_STEP}"
   --chunk_size 200000
 )
 
@@ -214,10 +267,11 @@ if [ -n "${OBS_SPACE_PRESSURE_HPA}" ]; then
   COMPARE_TO_GFS_ARGS+=(--pressure_hpa "${OBS_SPACE_PRESSURE_HPA}" --pressure_hpa_tol "${OBS_SPACE_PRESSURE_TOL_HPA}")
 fi
 
-"${PY[@]}" "${COMPARE_TO_GFS_SCRIPT}" "${COMPARE_TO_GFS_ARGS[@]}"
+if [ "${RUN_OBS_GFS_CSV}" = "1" ]; then
+  "${PY[@]}" "${COMPARE_TO_GFS_SCRIPT}" "${COMPARE_TO_GFS_ARGS[@]}"
 
-echo "==== 3b) Sanity-check GFS coverage (fail fast if missing) ===="
-"${PY[@]}" -c "
+  echo "==== 3b) Sanity-check GFS coverage (fail fast if missing) ===="
+  "${PY[@]}" -c "
 import pandas as pd
 p='${OUT_VS_GFS}'
 df=pd.read_csv(p, nrows=200000)
@@ -229,33 +283,40 @@ print(f'GFS coverage check: {non_null}/{len(df)} rows have at least one non-NaN 
 if non_null==0:
   raise SystemExit('ERROR: GFS columns are all NaN (check INIT_TIME and GFS_ROOT layout)')
 "
+else
+  echo "==== 3) Obs-space GFS CSV skipped (RUN_OBS_GFS_CSV=${RUN_OBS_GFS_CSV}) ===="
+fi
 
-echo "==== 4) Plots: RMSE vs fhr + maps (OCELOT vs Truth vs GFS) ===="
 PLOT_VARS="wind_temperature_pressure"
 if [ "${INSTRUMENT}" == "radiosonde" ] || [ "${INSTRUMENT}" == "aircraft" ]; then
   PLOT_VARS="wind_temperature"
 fi
 
-if [ "${INSTRUMENT}" == "radiosonde" ]; then
-  "${PY[@]}" "${PLOT_GFS_COMPARE_SCRIPT}" \
+if [ "${RUN_GFS_PLOTS}" = "1" ]; then
+  echo "==== 4) Plots: RMSE vs fhr + maps (OCELOT vs Truth vs GFS) ===="
+  if [ "${INSTRUMENT}" == "radiosonde" ]; then
+    "${PY[@]}" "${PLOT_GFS_COMPARE_SCRIPT}" \
+      --init_time "${INIT_TIME}" \
+      --data_dir "${OBS_DIR}" \
+      --plot_dir "${PLOT_GFS_DIR}" \
+      --instrument "${INSTRUMENT}" \
+      --vars "${PLOT_VARS}" \
+      --chunksize 200000 \
+      --maps --fhrs ${FHR_LIST} \
+      --levels ${RADIOSONDE_LEVELS} \
+      --level_tol_hpa ${RADIOSONDE_LEVEL_TOL_HPA}
+  else
+    "${PY[@]}" "${PLOT_GFS_COMPARE_SCRIPT}" \
     --init_time "${INIT_TIME}" \
     --data_dir "${OBS_DIR}" \
     --plot_dir "${PLOT_GFS_DIR}" \
     --instrument "${INSTRUMENT}" \
-    --vars "${PLOT_VARS}" \
+      --vars "${PLOT_VARS}" \
     --chunksize 200000 \
-    --maps --fhrs ${FHR_LIST} \
-    --levels ${RADIOSONDE_LEVELS} \
-    --level_tol_hpa ${RADIOSONDE_LEVEL_TOL_HPA}
+    --maps --fhrs ${FHR_LIST}
+  fi
 else
-  "${PY[@]}" "${PLOT_GFS_COMPARE_SCRIPT}" \
-  --init_time "${INIT_TIME}" \
-  --data_dir "${OBS_DIR}" \
-  --plot_dir "${PLOT_GFS_DIR}" \
-  --instrument "${INSTRUMENT}" \
-    --vars "${PLOT_VARS}" \
-  --chunksize 200000 \
-  --maps --fhrs ${FHR_LIST}
+  echo "==== 4) GFS plots skipped (RUN_GFS_PLOTS=${RUN_GFS_PLOTS}) ===="
 fi
 
 echo "==== 5) Mesh-grid: interpolate GFS onto OCELOT mesh grid (same points) ===="
@@ -306,26 +367,39 @@ if [ -d "${MESH_DIR}" ]; then
             exit 4
           fi
 
-          echo "[INFO] Building mesh-vs-GFS CSV for instrument=${mesh_instrument} fhr=${fhr}"
-          "${PY[@]}" "${COMPARE_MESH_TO_GFS_SCRIPT}" \
-            --mesh_csv "${mesh_csv}" \
-            --gfs_root "${GFS_ROOT}" \
-            --out_csv "${gfs_on_ocelot_mesh_csv}" \
-            --interp nearest
+          if [ "${RUN_MESH_GFS_CSV}" = "1" ]; then
+            echo "[INFO] Building mesh-vs-GFS CSV for instrument=${mesh_instrument} fhr=${fhr}"
+            "${PY[@]}" "${COMPARE_MESH_TO_GFS_SCRIPT}" \
+              --mesh_csv "${mesh_csv}" \
+              --gfs_root "${GFS_ROOT}" \
+              --out_csv "${gfs_on_ocelot_mesh_csv}" \
+              --interp nearest \
+              --analysis_time_mode "${ANALYSIS_TIME_MODE}"
+          else
+            echo "[INFO] Mesh-vs-GFS CSV skipped for instrument=${mesh_instrument} fhr=${fhr} (RUN_MESH_GFS_CSV=${RUN_MESH_GFS_CSV})"
+          fi
 
           # Plot a small set of variables if present.
-          mkdir -p "${PLOT_MESH_GFS_DIR}/fhr${fhr}"
-          mesh_vars="u10 v10 t2m sp"
-          if [ "${mesh_instrument}" == "radiosonde" ] || [ "${mesh_instrument}" == "aircraft" ]; then
-            mesh_vars="u v temp"
+          if [ "${RUN_MESH_GFS_PLOTS}" = "1" ]; then
+            if [ ! -f "${gfs_on_ocelot_mesh_csv}" ]; then
+              echo "[WARN] Mesh-vs-GFS plot skipped because CSV is missing: ${gfs_on_ocelot_mesh_csv}"
+            else
+              mkdir -p "${PLOT_MESH_GFS_DIR}/fhr${fhr}"
+              mesh_vars="u10 v10 t2m sp"
+              if [ "${mesh_instrument}" == "radiosonde" ] || [ "${mesh_instrument}" == "aircraft" ]; then
+                mesh_vars="u v temp"
+              fi
+              for v in ${mesh_vars}; do
+                "${PY[@]}" "${PLOT_MESH_VS_GFS_MAPS_SCRIPT}" \
+                  --csv "${gfs_on_ocelot_mesh_csv}" \
+                  --plot_dir "${PLOT_MESH_GFS_DIR}/fhr${fhr}" \
+                  --var "${v}" \
+                  --gfs_root "${GFS_ROOT}" || true
+              done
+            fi
+          else
+            echo "[INFO] Mesh-vs-GFS plots skipped for instrument=${mesh_instrument} fhr=${fhr} (RUN_MESH_GFS_PLOTS=${RUN_MESH_GFS_PLOTS})"
           fi
-          for v in ${mesh_vars}; do
-            "${PY[@]}" "${PLOT_MESH_VS_GFS_MAPS_SCRIPT}" \
-              --csv "${gfs_on_ocelot_mesh_csv}" \
-              --plot_dir "${PLOT_MESH_GFS_DIR}/fhr${fhr}" \
-              --var "${v}" \
-              --gfs_root "${GFS_ROOT}" || true
-          done
         else
           echo "[WARN] Mesh-grid CSV not found for instrument=${mesh_instrument} fhr=${fhr}: ${mesh_csv}"
         fi

--- a/gnn_model/evaluation/scripts/run_pred_eval_gfs_2025.sh
+++ b/gnn_model/evaluation/scripts/run_pred_eval_gfs_2025.sh
@@ -1,0 +1,116 @@
+#!/bin/bash -l
+#SBATCH --exclude=u22g09,u22g08,u22g10,u23g12
+#SBATCH -A gpu-emc-ai
+#SBATCH -p u1-h100
+#SBATCH -q gpu
+#SBATCH --gres=gpu:h100:1
+#SBATCH -J ocelot_2025_full
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=0
+#SBATCH -t 05:30:00
+#SBATCH --array=0-729
+#SBATCH --output=logs/ocelot_2025_full_%A_%a.out
+#SBATCH --error=logs/ocelot_2025_full_%A_%a.err
+#SBATCH --mail-type=BEGIN,END,FAIL
+
+set -euo pipefail
+
+SOURCE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -n "${GNN_MODEL_DIR:-}" && -f "${GNN_MODEL_DIR}/predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${GNN_MODEL_DIR}" && pwd)"
+elif [[ -n "${SLURM_SUBMIT_DIR:-}" && -f "${SLURM_SUBMIT_DIR}/predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${SLURM_SUBMIT_DIR}" && pwd)"
+elif [[ -f "${SOURCE_SCRIPT_DIR}/../../predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${SOURCE_SCRIPT_DIR}/../.." && pwd)"
+else
+  GNN_MODEL_DIR="/scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/main_PR/ocelot/gnn_model"
+fi
+SCRIPT_DIR="${GNN_MODEL_DIR}/evaluation/scripts"
+cd "${GNN_MODEL_DIR}"
+
+GFS_ROOT=${GFS_ROOT:-/scratch3/NCEPDEV/da/Mu-Chieh.Ko/JEDI-nudging/gfs-rt25}
+YEAR=${YEAR:-2025}
+
+# Date window. Override these at sbatch time for each 3-month chunk.
+INIT_START_DATE=${INIT_START_DATE:-20250101}
+INIT_END_DATE=${INIT_END_DATE:-20251231}
+
+# Which initialization times to generate:
+#   all      = every available requested cycle in the date window.
+#              For full 2025 with 00/12Z cycles this is 730 inits.
+#   sampled  = use NUM_INITS and INIT_SAMPLE_MODE below.
+INIT_SELECTION=${INIT_SELECTION:-all}
+
+# Used only when INIT_SELECTION=sampled.
+NUM_INITS=${NUM_INITS:-120}
+
+# Cycles to sample from.
+INIT_CYCLES=${INIT_CYCLES:-00,12}
+
+# Sampling mode:
+#   balanced_distinct = 30 different dates, half 00Z and half 12Z
+#   paired_cycles     = 15 dates × both 00Z and 12Z = 30 init times
+INIT_SAMPLE_MODE=${INIT_SAMPLE_MODE:-balanced_distinct}
+
+REQUIRED_FHRS=${REQUIRED_FHRS:-0,1,2,3,4,5,6,7,8,9,10,11,12}
+
+INIT_LIST_FILE="${SLURM_TMPDIR:-/tmp}/ocelot_init_times_${SLURM_JOB_ID:-manual}_${SLURM_ARRAY_TASK_ID:-0}.txt"
+INIT_LIST_ARGS=(
+  --gfs-root "${GFS_ROOT}"
+  --year "${YEAR}"
+  --start-date "${INIT_START_DATE}"
+  --end-date "${INIT_END_DATE}"
+  --cycles "${INIT_CYCLES}"
+  --required-fhrs "${REQUIRED_FHRS}"
+)
+if [[ "${INIT_SELECTION}" == "all" ]]; then
+  INIT_LIST_ARGS+=(--all-inits)
+else
+  INIT_LIST_ARGS+=(--num-inits "${NUM_INITS}" --sample-mode "${INIT_SAMPLE_MODE}")
+fi
+python "${SCRIPT_DIR}/make_2025_init.py" "${INIT_LIST_ARGS[@]}" > "${INIT_LIST_FILE}"
+mapfile -t INIT_TIMES < "${INIT_LIST_FILE}"
+
+if (( ${#INIT_TIMES[@]} == 0 )); then
+  echo "ERROR: no initialization times generated."
+  echo "       helper: ${SCRIPT_DIR}/make_2025_init.py"
+  echo "       GFS_ROOT=${GFS_ROOT}"
+  echo "       range=${INIT_START_DATE}..${INIT_END_DATE} cycles=${INIT_CYCLES} required_fhrs=${REQUIRED_FHRS}"
+  exit 2
+fi
+
+ARRAY_IDX=${SLURM_ARRAY_TASK_ID:-0}
+if (( ARRAY_IDX < 0 || ARRAY_IDX >= ${#INIT_TIMES[@]} )); then
+  echo "INFO: SLURM_ARRAY_TASK_ID=${ARRAY_IDX} out of range 0..$((${#INIT_TIMES[@]}-1)); skipping."
+  exit 0
+fi
+
+export INIT_TIME="${INIT_TIMES[${ARRAY_IDX}]}"
+
+# Manuscript checkpoint/current experiment defaults. Override at sbatch time if needed.
+export EXP_NAME=${EXP_NAME:-paper_2025_full_Epoch3079}
+export CKPT=${CKPT:-/scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/main_PR/ocelot/gnn_model/checkpoints/PR_Test/Epoch3079_fixedval.ckpt}
+export INSTRUMENT=${INSTRUMENT:-surface_obs}
+export GFS_ROOT
+export GFS_TIME_MODE=${GFS_TIME_MODE:-obs_interp}
+export GFS_FHR_STEP=${GFS_FHR_STEP:-1}
+export FHR_LIST=${FHR_LIST:-"3 6 9 12"}
+export ANALYSIS_TIME_MODE=${ANALYSIS_TIME_MODE:-exact}
+
+echo "===================================================================="
+echo " OCELOT 2025 GFS eval"
+echo "   array idx    : ${ARRAY_IDX} of ${#INIT_TIMES[@]}"
+echo "   INIT_TIME    : ${INIT_TIME}"
+echo "   init select  : ${INIT_SELECTION}"
+echo "   EXP_NAME     : ${EXP_NAME}"
+echo "   CKPT         : ${CKPT}"
+echo "   GFS_ROOT     : ${GFS_ROOT}"
+echo "   date range   : ${INIT_START_DATE}..${INIT_END_DATE}"
+echo "   GFS_TIME_MODE: ${GFS_TIME_MODE}"
+echo "   GFS_FHR_STEP : ${GFS_FHR_STEP}"
+echo "   ANALYSIS_MODE: ${ANALYSIS_TIME_MODE}"
+echo "===================================================================="
+
+bash "${SCRIPT_DIR}/run_pred_eval_gfs.sh"

--- a/gnn_model/evaluation/scripts/run_pred_eval_gfs_2025_cpu_csv.sh
+++ b/gnn_model/evaluation/scripts/run_pred_eval_gfs_2025_cpu_csv.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -l
+#SBATCH -A gpu-emc-ai
+#SBATCH -p u1-compute
+#SBATCH -J ocelot_2025_csv
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH -t 02:00:00
+#SBATCH --array=0-489%24
+#SBATCH --output=logs/ocelot_2025_csv_%A_%a.out
+#SBATCH --error=logs/ocelot_2025_csv_%A_%a.err
+#SBATCH --mail-type=BEGIN,END,FAIL
+
+set -euo pipefail
+
+SOURCE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -n "${GNN_MODEL_DIR:-}" && -f "${GNN_MODEL_DIR}/predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${GNN_MODEL_DIR}" && pwd)"
+elif [[ -n "${SLURM_SUBMIT_DIR:-}" && -f "${SLURM_SUBMIT_DIR}/predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${SLURM_SUBMIT_DIR}" && pwd)"
+elif [[ -f "${SOURCE_SCRIPT_DIR}/../../predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${SOURCE_SCRIPT_DIR}/../.." && pwd)"
+else
+  GNN_MODEL_DIR="/scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/main_PR/ocelot/gnn_model"
+fi
+SCRIPT_DIR="${GNN_MODEL_DIR}/evaluation/scripts"
+cd "${GNN_MODEL_DIR}"
+
+# Default to the 2025 remainder window: 2025-05-01 through 2025-12-31.
+# With 00/12Z cycles this is 245 days x 2 = 490 array tasks.
+export INIT_START_DATE=${INIT_START_DATE:-20250501}
+export INIT_END_DATE=${INIT_END_DATE:-20251231}
+
+# CPU post-processing mode: consume existing prediction CSVs, build CSV products,
+# and skip all per-init plotting.
+export RUN_PREDICTION=${RUN_PREDICTION:-0}
+export CSV_ONLY=${CSV_ONLY:-1}
+export RUN_TRUTH_PLOTS=${RUN_TRUTH_PLOTS:-0}
+export RUN_GFS_PLOTS=${RUN_GFS_PLOTS:-0}
+export RUN_MESH_GFS_PLOTS=${RUN_MESH_GFS_PLOTS:-0}
+
+# The manuscript scripts compute pooled metrics directly, so per-init metrics
+# are optional. Override RUN_METRICS=1 if you still want them.
+export RUN_METRICS=${RUN_METRICS:-0}
+export RUN_OBS_GFS_CSV=${RUN_OBS_GFS_CSV:-1}
+export RUN_MESH_GFS_CSV=${RUN_MESH_GFS_CSV:-1}
+
+bash "${SCRIPT_DIR}/run_pred_eval_gfs_2025.sh"

--- a/gnn_model/evaluation/scripts/run_pred_eval_gfs_2025_gpu_pred_only.sh
+++ b/gnn_model/evaluation/scripts/run_pred_eval_gfs_2025_gpu_pred_only.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -l
+#SBATCH --exclude=u22g09,u22g08,u22g10,u23g12
+#SBATCH -A gpu-emc-ai
+#SBATCH -p u1-h100
+#SBATCH -q gpu
+#SBATCH --gres=gpu:h100:1
+#SBATCH -J ocelot_2025_pred
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=0
+#SBATCH -t 02:00:00
+#SBATCH --array=0-489%24
+#SBATCH --output=logs/ocelot_2025_pred_%A_%a.out
+#SBATCH --error=logs/ocelot_2025_pred_%A_%a.err
+#SBATCH --mail-type=BEGIN,END,FAIL
+
+set -euo pipefail
+
+SOURCE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -n "${GNN_MODEL_DIR:-}" && -f "${GNN_MODEL_DIR}/predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${GNN_MODEL_DIR}" && pwd)"
+elif [[ -n "${SLURM_SUBMIT_DIR:-}" && -f "${SLURM_SUBMIT_DIR}/predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${SLURM_SUBMIT_DIR}" && pwd)"
+elif [[ -f "${SOURCE_SCRIPT_DIR}/../../predict_gnn.py" ]]; then
+  GNN_MODEL_DIR="$(cd "${SOURCE_SCRIPT_DIR}/../.." && pwd)"
+else
+  GNN_MODEL_DIR="/scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/main_PR/ocelot/gnn_model"
+fi
+SCRIPT_DIR="${GNN_MODEL_DIR}/evaluation/scripts"
+cd "${GNN_MODEL_DIR}"
+
+# Default to the remaining 2025 manuscript window:
+# 2025-05-01 through 2025-12-31, 00/12Z cycles = 490 tasks.
+export INIT_START_DATE=${INIT_START_DATE:-20250501}
+export INIT_END_DATE=${INIT_END_DATE:-20251231}
+
+# GPU prediction-only mode. GFS/analysis CSV generation is cheaper on CPU and
+# should be run afterward with run_pred_eval_gfs_2025_cpu_csv.sh.
+export RUN_PREDICTION=${RUN_PREDICTION:-1}
+export CSV_ONLY=${CSV_ONLY:-1}
+export RUN_TRUTH_PLOTS=${RUN_TRUTH_PLOTS:-0}
+export RUN_METRICS=${RUN_METRICS:-0}
+export RUN_OBS_GFS_CSV=${RUN_OBS_GFS_CSV:-0}
+export RUN_GFS_PLOTS=${RUN_GFS_PLOTS:-0}
+export RUN_MESH_GFS_CSV=${RUN_MESH_GFS_CSV:-0}
+export RUN_MESH_GFS_PLOTS=${RUN_MESH_GFS_PLOTS:-0}
+
+bash "${SCRIPT_DIR}/run_pred_eval_gfs_2025.sh"

--- a/gnn_model/evaluation/scripts/run_pred_eval_seasonal_cpu.sh
+++ b/gnn_model/evaluation/scripts/run_pred_eval_seasonal_cpu.sh
@@ -1,0 +1,202 @@
+#!/bin/bash -l
+#SBATCH -A da-cpu
+#SBATCH -p u1-service
+#SBATCH -J ocelot_seasonal
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=128G
+#SBATCH -t 24:00:00
+#SBATCH --output=logs/ocelot_seasonal_%A_%a.out
+#SBATCH --error=logs/ocelot_seasonal_%A_%a.err
+#SBATCH --array=0-15
+#SBATCH --mail-type=BEGIN,END,FAIL
+
+# =====================================================================
+# OCELOT-only multi-init seasonal prediction + evaluation (CPU).
+#
+# Generates predictions, OCELOT-vs-truth plots, and pointwise metrics
+# for the 16 seasonal init dates used to support the manuscript figures
+# (spatial_examples_panel, profiles_panel, Table 2, rollout_growth).
+#
+# This script does NOT run any GFS comparison (those inits are out of
+# the local GFS archive window). For GFS-compare figures, use
+# run_pred_eval_gfs.sh on the 2025-02-20..2025-04-01 set.
+#
+# Submit (array job, one init per task):
+#   cd /scratch4/.../main_PR/ocelot/gnn_model
+#   mkdir -p logs
+#   sbatch evaluation/scripts/run_pred_eval_seasonal_cpu.sh
+#
+# Submit a single init for testing:
+#   sbatch --array=0 evaluation/scripts/run_pred_eval_seasonal_cpu.sh
+#
+# Override checkpoint or experiment name:
+#   sbatch --export=ALL,CKPT=/path/to.ckpt,EXP_NAME=PR_Test \
+#       evaluation/scripts/run_pred_eval_seasonal_cpu.sh
+# =====================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -n "${SLURM_SUBMIT_DIR:-}" && -d "${SLURM_SUBMIT_DIR}" ]]; then
+  GNN_MODEL_DIR="$(cd "${SLURM_SUBMIT_DIR}" && pwd)"
+else
+  GNN_MODEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+fi
+OCELOT_DIR="$(cd "${GNN_MODEL_DIR}/.." && pwd)"
+
+cd "${SLURM_SUBMIT_DIR:-${GNN_MODEL_DIR}}"
+
+# ---------------------------------------------------------------------
+# 16 seasonal init dates (00Z), covering all four NH seasons in 2025.
+# Order matches SBATCH --array=0-15.
+# ---------------------------------------------------------------------
+INIT_TIMES=(
+  # Winter (NH)
+  2025010800
+  2025012200
+  2025020500
+  2025021900
+  # Spring (NH) / Autumn (SH)
+  2025031200
+  2025032600
+  2025040900
+  2025042300
+  # Summer (NH) / Winter (SH)
+  2025060400
+  2025070200
+  2025073000
+  2025081300
+  # Autumn (NH) / Spring (SH)
+  2025091000
+  2025100800
+  2025110500
+  2025120300
+)
+
+ARRAY_IDX=${SLURM_ARRAY_TASK_ID:-0}
+if (( ARRAY_IDX < 0 || ARRAY_IDX >= ${#INIT_TIMES[@]} )); then
+  echo "ERROR: SLURM_ARRAY_TASK_ID=${ARRAY_IDX} out of range 0..$((${#INIT_TIMES[@]}-1))"
+  exit 2
+fi
+INIT_TIME="${INIT_TIMES[${ARRAY_IDX}]}"
+
+# =====================
+# User-config parameters
+# =====================
+
+# All instruments used by the OCELOT-only manuscript figures.
+INSTRUMENTS=${INSTRUMENTS:-"surface_obs radiosonde aircraft atms amsua ssmis seviri avhrr ascat"}
+
+# Experiment name -> writes under predictions/<EXP_NAME>
+EXP_NAME=${EXP_NAME:-PR_Test}
+
+# Checkpoint (the 1556-epoch one used for the current manuscript).
+CKPT=${CKPT:-/scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/main_PR/ocelot/gnn_model/checkpoints/PR_Test/gnn-epoch-epoch=1556-val_loss-val_loss=0.18.ckpt}
+
+if [ ! -f "${CKPT}" ]; then
+  echo "ERROR: CKPT not found: ${CKPT}"
+  exit 2
+fi
+
+# Lead times to plot.
+EVAL_FHR_DEFAULT=${EVAL_FHR_DEFAULT:-3}
+
+# Optional extra args forwarded to evaluations.py (plots).
+EVAL_EXTRA_ARGS=${EVAL_EXTRA_ARGS:-""}
+
+# Outputs (must match run_pred_eval_gfs.sh layout so downstream
+# aggregation scripts can glob across all inits transparently).
+OUT_ROOT=${OUT_ROOT:-"predictions/${EXP_NAME}"}
+OBS_DIR=${OUT_ROOT}/pred_csv/obs-space
+PLOT_ROOT="evaluation/${OUT_ROOT}/figures"
+PLOT_TRUTH_DIR=${PLOT_ROOT}/ocelot_vs_truth/init_${INIT_TIME}
+
+EVAL_SCRIPT="evaluation/scripts/evaluations.py"
+
+# ---------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------
+OCELOT_ENV_HOME="${OCELOT_ENV_HOME:-/scratch4/NAGAPE/gpu-ai4wp/Azadeh.Gholoubi/ocelot_env}"
+MM="${MM:-${OCELOT_ENV_HOME}/micromamba/bin/micromamba}"
+export MAMBA_ROOT_PREFIX="${MAMBA_ROOT_PREFIX:-${OCELOT_ENV_HOME}/micromamba_root}"
+OCELOT_ENV_NAME="${OCELOT_ENV_NAME:-ocelot-cu121}"
+
+if [[ ! -x "${MM}" ]]; then
+  echo "ERROR: micromamba not found/executable at: ${MM}"
+  exit 2
+fi
+
+PY=("${MM}" run -n "${OCELOT_ENV_NAME}" python)
+
+# Make sure we run THIS checkout, and force CPU (no GPUs visible).
+export PYTHONPATH="${GNN_MODEL_DIR}:${OCELOT_DIR}:${PYTHONPATH:-}"
+export CUDA_VISIBLE_DEVICES=""
+
+# Thread tuning for CPU inference.
+export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-8}
+export MKL_NUM_THREADS=${OMP_NUM_THREADS}
+
+# Derived dates for predict_gnn.py (YYYY-MM-DD).
+INIT_DATE="${INIT_TIME:0:8}"
+START_DATE=$(date -u -d "${INIT_DATE} -1 day" +%Y-%m-%d)
+END_DATE=$(date -u -d "${INIT_DATE} +1 day" +%Y-%m-%d)
+
+echo "===================================================================="
+echo " OCELOT seasonal CPU eval"
+echo "   host         : $(hostname)"
+echo "   array idx    : ${ARRAY_IDX} of ${#INIT_TIMES[@]}"
+echo "   INIT_TIME    : ${INIT_TIME}"
+echo "   START_DATE   : ${START_DATE}"
+echo "   END_DATE     : ${END_DATE}"
+echo "   EXP_NAME     : ${EXP_NAME}"
+echo "   CKPT         : ${CKPT}"
+echo "   OUT_ROOT     : ${OUT_ROOT}"
+echo "   OMP_NUM_THR  : ${OMP_NUM_THREADS}"
+echo "===================================================================="
+
+mkdir -p "${OUT_ROOT}" "${PLOT_TRUTH_DIR}"
+
+# ---------------------------------------------------------------------
+# 1) Prediction (obs-space, with truth) -- CPU
+# ---------------------------------------------------------------------
+echo "==== 1) Prediction (CPU) for init=${INIT_TIME} ===="
+"${PY[@]}" predict_gnn.py \
+  --checkpoint "${CKPT}" \
+  --start_date "${START_DATE}" \
+  --end_date "${END_DATE}" \
+  --output_dir "${OUT_ROOT}" \
+  --eval-mode \
+  --devices 1 \
+  --num_nodes 1 \
+  --batch_size 1
+
+# ---------------------------------------------------------------------
+# 2) OCELOT-vs-truth plots (per lead hour, all instruments)
+# ---------------------------------------------------------------------
+echo "==== 2) OCELOT vs Truth plots ===="
+"${PY[@]}" "${EVAL_SCRIPT}" --mode plots --has_ground_truth \
+  --data_dir "${OBS_DIR}" \
+  --plot_dir "${PLOT_TRUTH_DIR}" \
+  --init_time "${INIT_TIME}" \
+  --fhr "${EVAL_FHR_DEFAULT}" \
+  --plot_all_fhrs \
+  --plot_horizon_12h \
+  ${EVAL_EXTRA_ARGS}
+
+# ---------------------------------------------------------------------
+# 3) Pointwise metrics (pred vs truth) -- one CSV per init
+#     These feed the multi-init pooled Table 2 + RMSE-vs-lead figures.
+# ---------------------------------------------------------------------
+echo "==== 3) Pointwise metrics (pred vs truth) ===="
+"${PY[@]}" "${EVAL_SCRIPT}" --mode metrics \
+  --data_dir "${OBS_DIR}" \
+  --metrics_pattern "pred_*init_${INIT_TIME}.csv" \
+  --metrics_out "${OUT_ROOT}/metrics_pointwise_init_${INIT_TIME}.csv" \
+  --metrics_groupby instrument,lead_hours_nominal
+
+echo "DONE init=${INIT_TIME}. Outputs:"
+echo "  Pred CSVs : ${OBS_DIR}"
+echo "  Plots     : ${PLOT_TRUTH_DIR}"
+echo "  Metrics   : ${OUT_ROOT}/metrics_pointwise_init_${INIT_TIME}.csv"

--- a/gnn_model/gnn_datamodule.py
+++ b/gnn_model/gnn_datamodule.py
@@ -93,6 +93,7 @@ class BinDataset(Dataset):
         observation_config,
         feature_stats=None,
         require_targets=True,
+        include_persistence_inputs=False,
         tag="TRAIN",
         verbose: bool = False,
     ):
@@ -103,6 +104,7 @@ class BinDataset(Dataset):
         self.observation_config = observation_config
         self.feature_stats = feature_stats
         self.require_targets = require_targets
+        self.include_persistence_inputs = bool(include_persistence_inputs)
         self.tag = tag
         self.verbose = bool(verbose)
 
@@ -122,6 +124,7 @@ class BinDataset(Dataset):
                 self.observation_config,
                 feature_stats=self.feature_stats,
                 require_targets=self.require_targets,
+                include_persistence_inputs=self.include_persistence_inputs,
             )
             bin_data = out[bin_name]
             graph_data = self.create_graph_fn(bin_data)
@@ -195,6 +198,7 @@ class GNNDataModule(pl.LightningDataModule):
         latent_step_hours = int(latent_step_hours) if latent_step_hours is not None else None
         self.save_hyperparameters()
         self.prediction_mode = bool(prediction_mode)
+        self.include_persistence_inputs = bool(prediction_mode)
 
         # If require_targets not specified, default based on prediction_mode
         # prediction_mode=True → require_targets=False (inference)
@@ -557,6 +561,15 @@ class GNNDataModule(pl.LightningDataModule):
         if "input_features_final" in inst_dict:
             data[node_type_input].x = _t32(inst_dict["input_features_final"])
 
+            if "input_features_raw" in inst_dict:
+                data[node_type_input].input_features_raw = _t32(inst_dict["input_features_raw"])
+            if "input_channel_mask" in inst_dict:
+                data[node_type_input].input_channel_mask = torch.as_tensor(
+                    inst_dict["input_channel_mask"], dtype=torch.bool
+                )
+            if "input_time_unix" in inst_dict:
+                data[node_type_input].input_times = _t64(inst_dict["input_time_unix"])
+
             # Store pressure level index for radiosonde and aircraft (if available)
             if "input_pressure_level" in inst_dict:
                 data[node_type_input].pressure_level = inst_dict["input_pressure_level"].long()
@@ -761,6 +774,7 @@ class GNNDataModule(pl.LightningDataModule):
             self.hparams.observation_config,
             feature_stats=self.feature_stats,
             require_targets=True,  # Training always requires targets
+            include_persistence_inputs=False,
             tag="TRAIN",
         )
         loader = PyGDataLoader(
@@ -787,6 +801,7 @@ class GNNDataModule(pl.LightningDataModule):
             self.hparams.observation_config,
             feature_stats=self.feature_stats,
             require_targets=True,  # Validation requires targets for comparison
+            include_persistence_inputs=self.include_persistence_inputs,
             tag="VAL",
         )
         loader = PyGDataLoader(
@@ -824,6 +839,7 @@ class GNNDataModule(pl.LightningDataModule):
             self.hparams.observation_config,
             feature_stats=self.feature_stats,
             require_targets=self.require_targets,  # Use datamodule's require_targets setting
+            include_persistence_inputs=self.include_persistence_inputs,
             tag="PREDICT",
         )
 
@@ -862,6 +878,7 @@ class GNNDataModule(pl.LightningDataModule):
             self.hparams.observation_config,
             feature_stats=self.feature_stats,
             require_targets=self.require_targets,
+            include_persistence_inputs=self.include_persistence_inputs,
             tag="FSOI",
         )
 

--- a/gnn_model/gnn_model.py
+++ b/gnn_model/gnn_model.py
@@ -2209,6 +2209,7 @@ class GNNLightning(pl.LightningModule):
         all_mask = []
         all_pressure = []  # Pressure in hPa for radiosonde/aircraft evaluation
         all_pressure_level = []  # Pressure level index (0-15) for stratified analysis
+        all_persist = []
 
         # Persist scan-angle conditioning inputs for satellite-style targets.
         # For these node types, batch[step_node_type].x stores scan angle(s).
@@ -2219,6 +2220,65 @@ class GNNLightning(pl.LightningModule):
             scan_angle_expected_dim = 1
 
         all_scan_angle_cols = [list() for _ in range(scan_angle_expected_dim)] if scan_angle_expected_dim > 0 else []
+
+        def _rounded_loc_keys(lat_deg, lon_deg, pressure_level=None):
+            lat_key = np.round(np.asarray(lat_deg, dtype=np.float64), 4)
+            lon_key = np.round(np.asarray(lon_deg, dtype=np.float64), 4)
+            if pressure_level is None:
+                return list(zip(lat_key.tolist(), lon_key.tolist()))
+            pressure_key = np.asarray(pressure_level, dtype=np.int64)
+            return list(zip(lat_key.tolist(), lon_key.tolist(), pressure_key.tolist()))
+
+        def _build_persistence_lookup():
+            input_node = node_type.replace("_target", "_input")
+            if input_node not in batch.node_types:
+                return None
+            store = batch[input_node]
+            required = ("input_features_raw", "input_times", "lat", "lon")
+            if not all(hasattr(store, name) for name in required):
+                return None
+
+            vals = store.input_features_raw.detach().cpu().numpy()
+            times = store.input_times.detach().cpu().numpy().astype(np.int64)
+            lat = store.lat.detach().cpu().numpy()
+            lon = store.lon.detach().cpu().numpy()
+            mask = None
+            if hasattr(store, "input_channel_mask"):
+                mask = store.input_channel_mask.detach().cpu().numpy().astype(bool)
+            pressure = None
+            if hasattr(store, "pressure_level"):
+                pressure = store.pressure_level.detach().cpu().numpy().astype(np.int64)
+
+            if vals.size == 0 or times.size != vals.shape[0]:
+                return None
+
+            cutoff = init_unix if init_unix >= 0 else None
+            latest = {}
+            for row, key in enumerate(_rounded_loc_keys(lat, lon, pressure)):
+                if cutoff is not None and times[row] > cutoff:
+                    continue
+                prev = latest.get(key)
+                if prev is None or times[row] > prev[0]:
+                    v = vals[row].astype(np.float64, copy=True)
+                    if mask is not None and mask.shape == vals.shape:
+                        v[~mask[row]] = np.nan
+                    latest[key] = (int(times[row]), v)
+            return latest, pressure is not None
+
+        # Init time columns (constant per file/batch when available)
+        init_time_str = self._extract_init_time_str(batch)
+        init_dt_str = ""
+        init_unix = -1
+        if init_time_str not in (None, '', 'unknown'):
+            try:
+                init_dt = pd.to_datetime(init_time_str, format='%Y%m%d%H', utc=True)
+                init_dt_str = init_dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+                init_unix = int(init_dt.timestamp())
+            except Exception:
+                init_dt_str = ""
+                init_unix = -1
+
+        persistence_lookup = _build_persistence_lookup()
 
         for step in range(len(preds_list)):
             if step >= len(preds_list) or step >= len(gts_list):
@@ -2327,6 +2387,26 @@ class GNNLightning(pl.LightningModule):
             all_pressure.extend(pressure_hpa)
             all_pressure_level.extend(pressure_level_idx)
 
+            persist = np.full(
+                y_true_unnorm.detach().cpu().numpy().shape,
+                np.nan,
+                dtype=np.float64,
+            )
+            if persistence_lookup is not None:
+                latest, needs_pressure = persistence_lookup
+                keys = _rounded_loc_keys(
+                    lat_deg,
+                    lon_deg,
+                    pressure_level_idx if needs_pressure else None,
+                )
+                for row, key in enumerate(keys):
+                    item = latest.get(key)
+                    if item is not None:
+                        vals = item[1]
+                        width = min(persist.shape[1], vals.shape[0])
+                        persist[row, :width] = vals[:width]
+            all_persist.append(persist)
+
             if valid_mask is not None:
                 all_mask.append(valid_mask.detach().cpu().numpy().astype(bool))
             else:
@@ -2345,6 +2425,7 @@ class GNNLightning(pl.LightningModule):
         all_pred_concat = np.vstack(all_pred)
         all_true_concat = np.vstack(all_true)
         all_mask_concat = np.vstack(all_mask)
+        all_persist_concat = np.vstack(all_persist) if all_persist else np.full_like(all_true_concat, np.nan, dtype=np.float64)
 
         # Skip saving if no real ground truth data
         if all_true_concat.size == 0:
@@ -2373,19 +2454,6 @@ class GNNLightning(pl.LightningModule):
         if all_scan_angle_cols and len(all_scan_angle_cols[0]) == len(df):
             for j in range(scan_angle_expected_dim):
                 df[f"scan_angle_{j}"] = np.asarray(all_scan_angle_cols[j], dtype=np.float64)
-
-        # Init time columns (constant per file/batch when available)
-        init_time_str = self._extract_init_time_str(batch)
-        init_dt_str = ""
-        init_unix = -1
-        if init_time_str not in (None, '', 'unknown'):
-            try:
-                init_dt = pd.to_datetime(init_time_str, format='%Y%m%d%H', utc=True)
-                init_dt_str = init_dt.strftime('%Y-%m-%dT%H:%M:%SZ')
-                init_unix = int(init_dt.timestamp())
-            except Exception:
-                init_dt_str = ""
-                init_unix = -1
 
         if init_dt_str:
             df.insert(0, 'init_datetime', init_dt_str)
@@ -2425,6 +2493,7 @@ class GNNLightning(pl.LightningModule):
         for i, fname in enumerate(feats):
             col = _safe_col_name(fname)
             df[f"pred_{col}"] = all_pred_concat[:, i]
+            df[f"persist_{col}"] = all_persist_concat[:, i]
             df[f"true_{col}"] = all_true_concat[:, i]
             df[f"mask_{col}"] = all_mask_concat[:, i]
 
@@ -2745,6 +2814,16 @@ class GNNLightning(pl.LightningModule):
             dict: Predictions for all node types
         """
         print(f"[PREDICT] Processing batch {batch_idx}: {batch.bin_name}")
+
+        target_init_filter = os.environ.get("PREDICT_INIT_TIME_FILTER", "").strip()
+        if target_init_filter:
+            batch_init_time = self._extract_init_time_str(batch)
+            if batch_init_time != target_init_filter:
+                print(
+                    f"[PREDICT] Skipping batch {batch_idx}: init_time={batch_init_time} "
+                    f"does not match PREDICT_INIT_TIME_FILTER={target_init_filter}"
+                )
+                return {}
 
         # Forward pass
         forward_output = self(batch)

--- a/gnn_model/process_timeseries.py
+++ b/gnn_model/process_timeseries.py
@@ -519,7 +519,15 @@ def _stats_from_cfg(feature_stats, inst_name, feat_keys):
 
 
 @timing_resource_decorator
-def extract_features(z_dict, data_summary, bin_name, observation_config, feature_stats=None, require_targets=True):
+def extract_features(
+    z_dict,
+    data_summary,
+    bin_name,
+    observation_config,
+    feature_stats=None,
+    require_targets=True,
+    include_persistence_inputs=False,
+):
     """
     Loads and normalizes features for each time bin.
     Adds per-channel masks for inputs and targets so features can be missing independently.
@@ -1303,6 +1311,14 @@ def extract_features(z_dict, data_summary, bin_name, observation_config, feature
             data_summary_bin["input_metadata"] = torch.tensor(np.column_stack([lat_rad_input, lon_rad_input]), dtype=torch.float32)
             data_summary_bin["input_lat_deg"] = input_lat_raw_clean
             data_summary_bin["input_lon_deg"] = input_lon_raw_clean
+            if include_persistence_inputs:
+                data_summary_bin["input_features_raw"] = input_features_raw_clean.astype(np.float32)
+                data_summary_bin["input_channel_mask"] = input_valid_ch_clean.astype(bool)
+                data_summary_bin["input_time_unix"] = np.asarray(input_times_clean, dtype=np.int64)
+            else:
+                data_summary_bin.pop("input_features_raw", None)
+                data_summary_bin.pop("input_channel_mask", None)
+                data_summary_bin.pop("input_time_unix", None)
 
             # Store pressure level indices for radiosonde and aircraft
             if inst_name in ['radiosonde', 'aircraft'] and input_pressure_level is not None:

--- a/gnn_model/run_gnn_Rand.sh
+++ b/gnn_model/run_gnn_Rand.sh
@@ -9,7 +9,7 @@
 #SBATCH --ntasks-per-node=2
 #SBATCH --cpus-per-task=4
 #SBATCH --mem=0
-#SBATCH -t 48:00:00
+#SBATCH -t 12:00:00
 #SBATCH --output=gnn_train_Random_%j.out
 #SBATCH --error=gnn_train_Random_%j.err
 #SBATCH --mail-type=BEGIN,END,FAIL
@@ -99,7 +99,7 @@ nvidia-smi
 # New experiment name (override on submit if desired).
 # Example:
 #   sbatch --export=ALL,RUN_NAME=seq_convfocus_nl16 run_gnn_modified_sequential.sh
-RUN_NAME="${RUN_NAME:-Rand_TenYear_Test}"
+RUN_NAME="${RUN_NAME:-PR_Test}"
 echo "RUN_NAME=$RUN_NAME"
 
 # Loss/optimizer settings


### PR DESCRIPTION
## Summary

This PR adds persistence-baseline support across both obs-space and mesh-space evaluation outputs, and expands the OCELOT vs GFS evaluation workflow.

## Changes

- Add persistence input handling during prediction/evaluation data loading.
- Write `persist_*` columns alongside `pred_*`, `true_*`, and `mask_*` outputs.
- Support persistence in both:
  - obs-space prediction CSVs
  - mesh-grid prediction CSVs
- Match mesh persistence by lat/lon, and by pressure level for radiosonde/aircraft.
- Extend metrics evaluation to treat `persist_*` columns as a `persistence` baseline.
- Extend mesh-vs-GFS comparison scripts to preserve persistence columns while adding GFS forecast fields.
- Add optional GFS analysis support with:
  - `anl_*` columns
  - `valid_time`
  - `analysis_time_mode`
  - `ocelot_minus_anl_*`
  - `gfs_minus_anl_*`
- Add 6-panel mesh plotting when analysis is available:
  - OCELOT forecast
  - GFS forecast
  - GFS analysis
  - OCELOT - GFS
  - OCELOT - analysis
  - GFS - analysis
- Preserve surface, radiosonde, and aircraft mesh evaluation support.
- Add 2025 and seasonal evaluation helper scripts.
## Example Output

Example surface evaluation plot with OCELOT, persistence, and GFS comparison:

<img width="2864" height="930" alt="surface_obs_rmse_ocelot_gfs_persistence_pooled_clean" src="https://github.com/user-attachments/assets/d58b6cff-36f5-4e60-9d1e-cd359eeb9965" />
